### PR TITLE
Fix missing exercise images in monnaie and syllabe modules

### DIFF
--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -1,18 +1,30 @@
+import OneCentImage from '../../public/images/monnaie/1cent.png';
+import TwoCentsImage from '../../public/images/monnaie/2cents.png';
+import FiveCentsImage from '../../public/images/monnaie/5cents.png';
+import TenCentsImage from '../../public/images/monnaie/10cents.png';
+import TwentyCentsImage from '../../public/images/monnaie/20cents.png';
+import FiftyCentsImage from '../../public/images/monnaie/50cents.png';
+import OneEuroImage from '../../public/images/monnaie/1euro.png';
+import TwoEurosImage from '../../public/images/monnaie/2euros.png';
+import FiveEurosImage from '../../public/images/monnaie/5euros.png';
+import TenEurosImage from '../../public/images/monnaie/10euros.png';
+import TwentyEurosImage from '../../public/images/monnaie/20euros.png';
+import FiftyEurosImage from '../../public/images/monnaie/50euros.png';
 
 
 export const currency = [
-    { name: '1c', value: 0.01, image: '/images/monnaie/1cent.png', type: 'pièce' },
-    { name: '2c', value: 0.02, image: '/images/monnaie/2cents.png', type: 'pièce' },
-    { name: '5c', value: 0.05, image: '/images/monnaie/5cents.png', type: 'pièce' },
-    { name: '10c', value: 0.10, image: '/images/monnaie/10cents.png', type: 'pièce' },
-    { name: '20c', value: 0.20, image: '/images/monnaie/20cents.png', type: 'pièce' },
-    { name: '50c', value: 0.50, image: '/images/monnaie/50cents.png', type: 'pièce' },
-    { name: '1€', value: 1.00, image: '/images/monnaie/1euro.png', type: 'pièce' },
-    { name: '2€', value: 2.00, image: '/images/monnaie/2euros.png', type: 'pièce' },
-    { name: '5€', value: 5.00, image: '/images/monnaie/5euros.png', type: 'billet' },
-    { name: '10€', value: 10.00, image: '/images/monnaie/10euros.png', type: 'billet' },
-    { name: '20€', value: 20.00, image: '/images/monnaie/20euros.png', type: 'billet' },
-    { name: '50€', value: 50.00, image: '/images/monnaie/50euros.png', type: 'billet' },
+    { name: '1c', value: 0.01, image: OneCentImage.src, type: 'pièce' },
+    { name: '2c', value: 0.02, image: TwoCentsImage.src, type: 'pièce' },
+    { name: '5c', value: 0.05, image: FiveCentsImage.src, type: 'pièce' },
+    { name: '10c', value: 0.10, image: TenCentsImage.src, type: 'pièce' },
+    { name: '20c', value: 0.20, image: TwentyCentsImage.src, type: 'pièce' },
+    { name: '50c', value: 0.50, image: FiftyCentsImage.src, type: 'pièce' },
+    { name: '1€', value: 1.00, image: OneEuroImage.src, type: 'pièce' },
+    { name: '2€', value: 2.00, image: TwoEurosImage.src, type: 'pièce' },
+    { name: '5€', value: 5.00, image: FiveEurosImage.src, type: 'billet' },
+    { name: '10€', value: 10.00, image: TenEurosImage.src, type: 'billet' },
+    { name: '20€', value: 20.00, image: TwentyEurosImage.src, type: 'billet' },
+    { name: '50€', value: 50.00, image: FiftyEurosImage.src, type: 'billet' },
 ];
 
 export const euroPiecesAndBillets = currency.filter(c => c.value >= 1); // Only euros

--- a/src/lib/syllable-data.ts
+++ b/src/lib/syllable-data.ts
@@ -1,3 +1,43 @@
+import BallonImage from '../../public/images/syllables/ballon.png';
+import BateauImage from '../../public/images/syllables/bateau.png';
+import BananeImage from '../../public/images/syllables/banane.png';
+import BonbonImage from '../../public/images/syllables/bonbon.png';
+import CanardImage from '../../public/images/syllables/canard.png';
+import CamionImage from '../../public/images/syllables/camion.png';
+import CadeauImage from '../../public/images/syllables/cadeau.png';
+import ChevalImage from '../../public/images/syllables/cheval.png';
+import ChouchouImage from '../../public/images/syllables/chouchou.png';
+import CitronImage from '../../public/images/syllables/citron.png';
+import CochonImage from '../../public/images/syllables/cochon.png';
+import DominoImage from '../../public/images/syllables/domino.png';
+import FourmiImage from '../../public/images/syllables/fourmi.png';
+import FuseeImage from '../../public/images/syllables/fusee.png';
+import GateauImage from '../../public/images/syllables/gateau.png';
+import GirafeImage from '../../public/images/syllables/girafe.png';
+import LapinImage from '../../public/images/syllables/lapin.png';
+import LitImage from '../../public/images/syllables/lit.png';
+import LuneImage from '../../public/images/syllables/lune.png';
+import MaisonImage from '../../public/images/syllables/maison.png';
+import MotoImage from '../../public/images/syllables/moto.png';
+import MoutonImage from '../../public/images/syllables/mouton.png';
+import MurImage from '../../public/images/syllables/mur.png';
+import PapaImage from '../../public/images/syllables/papa.png';
+import PapillonImage from '../../public/images/syllables/papillon.png';
+import PizzaImage from '../../public/images/syllables/pizza.png';
+import PommeImage from '../../public/images/syllables/pomme.png';
+import PouleImage from '../../public/images/syllables/poule.png';
+import RatImage from '../../public/images/syllables/rat.png';
+import RobotImage from '../../public/images/syllables/robot.png';
+import SapinImage from '../../public/images/syllables/sapin.png';
+import SacImage from '../../public/images/syllables/sac.png';
+import SireneImage from '../../public/images/syllables/sirene.png';
+import SucreImage from '../../public/images/syllables/sucre.png';
+import TapisImage from '../../public/images/syllables/tapis.png';
+import TasseImage from '../../public/images/syllables/tasse.png';
+import TomateImage from '../../public/images/syllables/tomate.png';
+import VacheImage from '../../public/images/syllables/vache.png';
+import VeloImage from '../../public/images/syllables/velo.png';
+import VoitureImage from '../../public/images/syllables/voiture.png';
 
 
 export interface SyllableData {
@@ -7,44 +47,44 @@ export interface SyllableData {
 }
 
 export const syllableAttackData: SyllableData[] = [
-  { syllable: 'ba', word: 'ballon', image: '/images/syllables/ballon.png' },
-  { syllable: 'ba', word: 'bateau', image: '/images/syllables/bateau.png' },
-  { syllable: 'ba', word: 'banane', image: '/images/syllables/banane.png' },
-  { syllable: 'bon', word: 'bonbon', image: '/images/syllables/bonbon.png' },
-  { syllable: 'ca', word: 'canard', image: '/images/syllables/canard.png' },
-  { syllable: 'ca', word: 'camion', image: '/images/syllables/camion.png' },
-  { syllable: 'ca', word: 'cadeau', image: '/images/syllables/cadeau.png' },
-  { syllable: 'che', word: 'cheval', image: '/images/syllables/cheval.png' },
-  { syllable: 'chou', word: 'chouchou', image: '/images/syllables/chouchou.png' },
-  { syllable: 'ci', word: 'citron', image: '/images/syllables/citron.png' },
-  { syllable: 'co', word: 'cochon', image: '/images/syllables/cochon.png' },
-  { syllable: 'do', word: 'domino', image: '/images/syllables/domino.png' },
-  { syllable: 'four', word: 'fourmi', image: '/images/syllables/fourmi.png' },
-  { syllable: 'fu', word: 'fusée', image: '/images/syllables/fusee.png' },
-  { syllable: 'ga', word: 'gâteau', image: '/images/syllables/gateau.png' },
-  { syllable: 'gi', word: 'girafe', image: '/images/syllables/girafe.png' },
-  { syllable: 'la', word: 'lapin', image: '/images/syllables/lapin.png' },
-  { syllable: 'li', word: 'lit', image: '/images/syllables/lit.png' },
-  { syllable: 'lu', word: 'lune', image: '/images/syllables/lune.png' },
-  { syllable: 'mai', word: 'maison', image: '/images/syllables/maison.png' },
-  { syllable: 'mo', word: 'moto', image: '/images/syllables/moto.png' },
-  { syllable: 'mou', word: 'mouton', image: '/images/syllables/mouton.png' },
-  { syllable: 'mur', word: 'mur', image: '/images/syllables/mur.png' },
-  { syllable: 'papa', word: 'papa', image: '/images/syllables/papa.png' },
-  { syllable: 'pa', word: 'papillon', image: '/images/syllables/papillon.png' },
-  { syllable: 'pi', word: 'pizza', image: '/images/syllables/pizza.png' },
-  { syllable: 'po', word: 'pomme', image: '/images/syllables/pomme.png' },
-  { syllable: 'pou', word: 'poule', image: '/images/syllables/poule.png' },
-  { syllable: 'ra', word: 'rat', image: '/images/syllables/rat.png' },
-  { syllable: 'ro', word: 'robot', image: '/images/syllables/robot.png' },
-  { syllable: 'sa', word: 'sapin', image: '/images/syllables/sapin.png' },
-  { syllable: 'sa', word: 'sac', image: '/images/syllables/sac.png' },
-  { syllable: 'si', word: 'sirène', image: '/images/syllables/sirene.png' },
-  { syllable: 'su', word: 'sucre', image: '/images/syllables/sucre.png' },
-  { syllable: 'ta', word: 'tapis', image: '/images/syllables/tapis.png' },
-  { syllable: 'ta', word: 'tasse', image: '/images/syllables/tasse.png' },
-  { syllable: 'to', word: 'tomate', image: '/images/syllables/tomate.png' },
-  { syllable: 'va', word: 'vache', image: '/images/syllables/vache.png' },
-  { syllable: 'vé', word: 'vélo', image: '/images/syllables/velo.png' },
-  { syllable: 'voi', word: 'voiture', image: '/images/syllables/voiture.png' },
+  { syllable: 'ba', word: 'ballon', image: BallonImage.src },
+  { syllable: 'ba', word: 'bateau', image: BateauImage.src },
+  { syllable: 'ba', word: 'banane', image: BananeImage.src },
+  { syllable: 'bon', word: 'bonbon', image: BonbonImage.src },
+  { syllable: 'ca', word: 'canard', image: CanardImage.src },
+  { syllable: 'ca', word: 'camion', image: CamionImage.src },
+  { syllable: 'ca', word: 'cadeau', image: CadeauImage.src },
+  { syllable: 'che', word: 'cheval', image: ChevalImage.src },
+  { syllable: 'chou', word: 'chouchou', image: ChouchouImage.src },
+  { syllable: 'ci', word: 'citron', image: CitronImage.src },
+  { syllable: 'co', word: 'cochon', image: CochonImage.src },
+  { syllable: 'do', word: 'domino', image: DominoImage.src },
+  { syllable: 'four', word: 'fourmi', image: FourmiImage.src },
+  { syllable: 'fu', word: 'fusée', image: FuseeImage.src },
+  { syllable: 'ga', word: 'gâteau', image: GateauImage.src },
+  { syllable: 'gi', word: 'girafe', image: GirafeImage.src },
+  { syllable: 'la', word: 'lapin', image: LapinImage.src },
+  { syllable: 'li', word: 'lit', image: LitImage.src },
+  { syllable: 'lu', word: 'lune', image: LuneImage.src },
+  { syllable: 'mai', word: 'maison', image: MaisonImage.src },
+  { syllable: 'mo', word: 'moto', image: MotoImage.src },
+  { syllable: 'mou', word: 'mouton', image: MoutonImage.src },
+  { syllable: 'mur', word: 'mur', image: MurImage.src },
+  { syllable: 'papa', word: 'papa', image: PapaImage.src },
+  { syllable: 'pa', word: 'papillon', image: PapillonImage.src },
+  { syllable: 'pi', word: 'pizza', image: PizzaImage.src },
+  { syllable: 'po', word: 'pomme', image: PommeImage.src },
+  { syllable: 'pou', word: 'poule', image: PouleImage.src },
+  { syllable: 'ra', word: 'rat', image: RatImage.src },
+  { syllable: 'ro', word: 'robot', image: RobotImage.src },
+  { syllable: 'sa', word: 'sapin', image: SapinImage.src },
+  { syllable: 'sa', word: 'sac', image: SacImage.src },
+  { syllable: 'si', word: 'sirène', image: SireneImage.src },
+  { syllable: 'su', word: 'sucre', image: SucreImage.src },
+  { syllable: 'ta', word: 'tapis', image: TapisImage.src },
+  { syllable: 'ta', word: 'tasse', image: TasseImage.src },
+  { syllable: 'to', word: 'tomate', image: TomateImage.src },
+  { syllable: 'va', word: 'vache', image: VacheImage.src },
+  { syllable: 'vé', word: 'vélo', image: VeloImage.src },
+  { syllable: 'voi', word: 'voiture', image: VoitureImage.src },
 ];


### PR DESCRIPTION
## Summary
- import currency exercise assets as static modules so Next.js bundles them for production
- update syllable attack dataset to reference bundled image imports instead of public paths

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cca64173788325accec4a791fe384c