### PR TITLE
Fix syllabe d'attaque exercise image rendering

### DIFF
--- a/src/lib/syllabe-questions.ts
+++ b/src/lib/syllabe-questions.ts
@@ -19,8 +19,8 @@ export async function generateSyllabeAttaqueQuestion(): Promise<Question> {
     }
     
     const imageOptions = [
-        { src: correctItem.image, alt: correctItem.word, hint: correctItem.word },
-        ...Array.from(distractors)
+        { src: correctItem.image, alt: correctItem.word, value: correctItem.word, hint: correctItem.word },
+        ...Array.from(distractors).map(option => ({ ...option, value: option.alt }))
     ].sort(() => Math.random() - 0.5);
 
     return {
@@ -30,6 +30,6 @@ export async function generateSyllabeAttaqueQuestion(): Promise<Question> {
         question: 'Clique sur l\'image qui commence par la syllabe :',
         syllable: correctItem.syllable,
         answer: correctItem.word,
-        images: imageOptions,
+        imageOptions,
     };
 }


### PR DESCRIPTION
## Summary
- ensure Syllabe d'attaque questions expose imageOptions expected by the exercise workspace
- attach the answer value to each image option so the selected image can be validated client-side

## Testing
- npm run lint *(fails: interactive configuration prompt from `next lint`)*

------
https://chatgpt.com/codex/tasks/task_e_68ccada920388325ac00ec44edd968cf