### PR TITLE
Ensure public assets are deployed with Firebase Hosting

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,6 @@
 {
   "hosting": {
+    "public": "public",
     "rewrites": [
       {
         "source": "**",


### PR DESCRIPTION
## Summary
- configure Firebase Hosting to upload the `public` directory so statically referenced fonts remain available after deployment

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68d85602186c8325a65cc0dd62fae13b