### PR TITLE
Réorganise le terrain de boccia en mode paysage

### DIFF
--- a/src/components/boccia-game.tsx
+++ b/src/components/boccia-game.tsx
@@ -2,18 +2,16 @@
 'use client';
 
 import * as React from 'react';
-import { Card, CardHeader, CardTitle, CardContent } from './ui/card';
 import { Button } from './ui/button';
-import { ArrowLeft, RefreshCw, Gem } from 'lucide-react';
+import { ArrowLeft, RefreshCw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useToast } from '@/hooks/use-toast';
 import { Progress } from './ui/progress';
 
 // --- CONSTANTES DU JEU ---
-const GAME_WIDTH = 800;
-const THROWING_AREA_HEIGHT = 250;
-const GAME_HEIGHT = 600;
-const TOTAL_HEIGHT = GAME_HEIGHT + THROWING_AREA_HEIGHT;
+const DEFAULT_WIDTH = 1200;
+const DEFAULT_HEIGHT = 650;
+const THROWING_AREA_RATIO = 0.25;
 const BALL_RADIUS = 15;
 const FRICTION = 0.98;
 const MIN_VELOCITY = 0.05;
@@ -42,23 +40,50 @@ type Ball = {
 };
 
 const INITIAL_BALLS_PER_PLAYER = 6;
+const THROW_Y_RATIO: Record<'white' | Player, number> = {
+  white: 0.5,
+  red: 0.35,
+  blue: 0.65
+};
 
 export function BocciaGame({ onExit }: { onExit: () => void; }) {
   const [balls, setBalls] = React.useState<Ball[]>([]);
   const [phase, setPhase] = React.useState<GamePhase>('newRound');
   const [currentPlayer, setCurrentPlayer] = React.useState<Player>('red');
+  const [nextStartingPlayer, setNextStartingPlayer] = React.useState<Player>('red');
   const [ballsLeft, setBallsLeft] = React.useState<Record<Player, number>>({ red: INITIAL_BALLS_PER_PLAYER, blue: INITIAL_BALLS_PER_PLAYER });
   const [roundScore, setRoundScore] = React.useState<Record<Player, number>>({ red: 0, blue: 0 });
   const [totalScore, setTotalScore] = React.useState<Record<Player, number>>({ red: 0, blue: 0 });
-  const [roundWinner, setRoundWinner] = React.useState<Player | null>('red');
+  const [roundWinner, setRoundWinner] = React.useState<Player | null>(null);
+  const [jackNeedsPlacement, setJackNeedsPlacement] = React.useState(true);
+  const [roundNumber, setRoundNumber] = React.useState(1);
+  const [areaSize, setAreaSize] = React.useState({ width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT });
 
   const [aimingPhase, setAimingPhase] = React.useState<AimingPhase>('idle');
   const [ballToPlay, setBallToPlay] = React.useState<Ball | null>(null);
   const [aimingLine, setAimingLine] = React.useState<{ start: Vector; end: Vector } | null>(null);
   const [power, setPower] = React.useState(0);
+  const activePointerId = React.useRef<number | null>(null);
+  const lastThrowerRef = React.useRef<Player>('red');
+  const roundStarterRef = React.useRef<Player>('red');
 
   const gameAreaRef = React.useRef<HTMLDivElement>(null);
   const { toast } = useToast();
+  
+  const throwAreaWidth = React.useMemo(() => {
+    const availableWidth = areaSize.width;
+    if (availableWidth <= 400) {
+      return availableWidth * 0.4;
+    }
+    const minWidth = 200;
+    const maxWidth = Math.max(minWidth, availableWidth - 400);
+    const target = availableWidth * THROWING_AREA_RATIO;
+    return Math.min(Math.max(minWidth, target), maxWidth);
+  }, [areaSize.width]);
+
+  const fieldStartX = throwAreaWidth;
+  const totalWidth = areaSize.width;
+  const totalHeight = areaSize.height;
 
   React.useEffect(() => {
     if (phase === 'roundEnd') {
@@ -70,84 +95,90 @@ export function BocciaGame({ onExit }: { onExit: () => void; }) {
         });
       } else {
         const jack = balls.find(b => b.color === 'white');
-        if (!jack || jack.y >= GAME_HEIGHT) {
-            toast({
-              title: "Lancer du Jack raté !",
-              description: "Le Jack doit s'arrêter dans la zone verte."
-            });
+        if (!jack || jack.x <= fieldStartX || jack.x >= totalWidth) {
+          toast({
+            title: "Lancer du Jack raté !",
+            description: "Le Jack doit s'arrêter sur le terrain."
+          });
         } else {
-            toast({
-              title: "Fin de la manche !",
-              description: "Égalité, aucun point marqué."
-            });
+          toast({
+            title: "Fin de la manche !",
+            description: "Égalité, aucun point marqué."
+          });
         }
       }
     }
-  }, [phase, roundWinner, roundScore, toast, balls]);
+  }, [phase, roundWinner, roundScore, toast, balls, fieldStartX, totalWidth]);
 
 
-  const startNewRound = React.useCallback(() => {
-    // Le joueur qui commence est celui qui a gagné la manche précédente.
-    // Si la manche était nulle (lancer de jack raté), c'est à l'autre joueur.
-    const startingPlayer = roundWinner === null ? (currentPlayer === 'red' ? 'blue' : 'red') : roundWinner;
-    
+  const startNewRound = React.useCallback((forcedStarter?: Player, resetRound?: boolean) => {
     setBalls([]);
-    setCurrentPlayer(startingPlayer); 
+    setJackNeedsPlacement(true);
+    const starter = forcedStarter ?? nextStartingPlayer;
+    setCurrentPlayer(starter);
+    roundStarterRef.current = starter;
     setBallsLeft({ red: INITIAL_BALLS_PER_PLAYER, blue: INITIAL_BALLS_PER_PLAYER });
     setRoundScore({ red: 0, blue: 0 });
+    setBallToPlay(null);
+    setAimingLine(null);
+    setAimingPhase('idle');
+    setPower(0);
     setPhase('newRound');
-  }, [roundWinner, currentPlayer]);
+    setRoundNumber(prev => (resetRound ? 1 : prev + 1));
+  }, [nextStartingPlayer]);
 
   const resetGame = React.useCallback(() => {
     setTotalScore({ red: 0, blue: 0 });
-    setRoundWinner('red'); // Red starts the very first round
-    startNewRound();
+    setRoundWinner(null);
+    setNextStartingPlayer('red');
+    startNewRound('red', true);
   }, [startNewRound]);
 
   React.useEffect(() => {
     resetGame();
   }, [resetGame]);
   
-  const determineNextPlayer = React.useCallback((): Player => {
-    const jack = balls.find(b => b.color === 'white');
-    
-    // Case 1: Jack has just been thrown. It's the other player's turn.
-    if (balls.length === 1 && jack) {
-        return currentPlayer === 'red' ? 'blue' : 'red';
+  const determineNextPlayer = React.useCallback((stateBalls: Ball[], stateBallsLeft: Record<Player, number>, activePlayer: Player): Player => {
+    const jack = stateBalls.find(b => b.color === 'white');
+
+    if (!jack || jack.x <= fieldStartX || jack.x >= totalWidth) return activePlayer;
+
+    const inPlayBalls = stateBalls.filter(b => b.x >= fieldStartX && b.x <= totalWidth && b.color !== 'white');
+
+    if (inPlayBalls.length === 0) {
+      return activePlayer;
     }
 
-    if (!jack || jack.y >= GAME_HEIGHT) return currentPlayer;
+    const redBallsInPlay = inPlayBalls.filter(b => b.color === 'red');
+    const blueBallsInPlay = inPlayBalls.filter(b => b.color === 'blue');
 
-    const redBallsInPlay = balls.filter(b => b.color === 'red' && b.y < GAME_HEIGHT);
-    const blueBallsInPlay = balls.filter(b => b.color === 'blue' && b.y < GAME_HEIGHT);
-    
-    if (redBallsInPlay.length === 0 && ballsLeft.red > 0) return 'red';
-    if (blueBallsInPlay.length === 0 && ballsLeft.blue > 0) return 'blue';
-  
-    const redDistances = redBallsInPlay.map(b => Math.hypot(b.x - jack.x, b.y - jack.y)).sort((a, b) => a - b);
-    const blueDistances = blueBallsInPlay.map(b => Math.hypot(b.x - jack.x, b.y - jack.y)).sort((a, b) => a - b);
-  
-    const closestRed = redDistances[0] ?? Infinity;
-    const closestBlue = blueDistances[0] ?? Infinity;
-  
+    if (redBallsInPlay.length === 0 && stateBallsLeft.red > 0) return 'red';
+    if (blueBallsInPlay.length === 0 && stateBallsLeft.blue > 0) return 'blue';
+
+    const redDistances = redBallsInPlay.map(b => Math.hypot(b.x - jack.x, b.y - jack.y));
+    const blueDistances = blueBallsInPlay.map(b => Math.hypot(b.x - jack.x, b.y - jack.y));
+
+    const closestRed = redDistances.length ? Math.min(...redDistances) : Infinity;
+    const closestBlue = blueDistances.length ? Math.min(...blueDistances) : Infinity;
+
     const nextPlayer = closestRed <= closestBlue ? 'blue' : 'red';
-  
-    if (ballsLeft[nextPlayer] > 0) {
+
+    if (stateBallsLeft[nextPlayer] > 0) {
       return nextPlayer;
     }
     return nextPlayer === 'red' ? 'blue' : 'red';
-  }, [balls, ballsLeft, currentPlayer]);
-  
-  const calculateRoundScore = () => {
+  }, [fieldStartX, totalWidth]);
+
+  const calculateRoundScore = React.useCallback(() => {
     const jack = balls.find(b => b.color === 'white');
-    if (!jack || jack.y >= GAME_HEIGHT) {
+    if (!jack || jack.x <= fieldStartX || jack.x >= totalWidth) {
         setRoundWinner(null);
         setPhase('roundEnd');
         return;
     }
 
-    const redBallsInPlay = balls.filter(b => b.color === 'red' && b.y < GAME_HEIGHT);
-    const blueBallsInPlay = balls.filter(b => b.color === 'blue' && b.y < GAME_HEIGHT);
+    const redBallsInPlay = balls.filter(b => b.color === 'red' && b.x >= fieldStartX && b.x <= totalWidth);
+    const blueBallsInPlay = balls.filter(b => b.color === 'blue' && b.x >= fieldStartX && b.x <= totalWidth);
 
     if(redBallsInPlay.length === 0 && blueBallsInPlay.length === 0) {
         setRoundWinner(null);
@@ -182,23 +213,34 @@ export function BocciaGame({ onExit }: { onExit: () => void; }) {
       setRoundScore({ red: winner === 'red' ? score : 0, blue: winner === 'blue' ? score : 0 });
       setTotalScore(prev => ({...prev, [winner!]: prev[winner!] + score}));
       setRoundWinner(winner);
+      setNextStartingPlayer(winner);
     } else {
       setRoundWinner(null);
+      setNextStartingPlayer(roundStarterRef.current);
     }
     setPhase('roundEnd');
-  }
+  }, [balls, fieldStartX, totalWidth]);
+
+  const getThrowOrigin = React.useCallback((color: 'white' | Player): Vector => {
+    return {
+      x: throwAreaWidth * 0.5,
+      y: totalHeight * THROW_Y_RATIO[color]
+    };
+  }, [throwAreaWidth, totalHeight]);
 
   const getBallToPlay = React.useCallback(() => {
-     const isJackTurn = !balls.some(b => b.color === 'white');
-     
-     if (isJackTurn) {
-        return { id: 0, x: GAME_WIDTH / 2, y: GAME_HEIGHT + THROWING_AREA_HEIGHT / 2, vx: 0, vy: 0, color: 'white' as const };
-     } else {
-         if (ballsLeft[currentPlayer] <= 0) return null;
-         const newId = (currentPlayer === 'red' ? 100 : 200) + (INITIAL_BALLS_PER_PLAYER - ballsLeft[currentPlayer]);
-         return { id: newId, x: GAME_WIDTH / 2, y: GAME_HEIGHT + THROWING_AREA_HEIGHT / 2, vx: 0, vy: 0, color: currentPlayer };
+     if (jackNeedsPlacement) {
+        const origin = getThrowOrigin('white');
+        return { id: 0, x: origin.x, y: origin.y, vx: 0, vy: 0, color: 'white' as const };
      }
-  }, [balls, ballsLeft, currentPlayer]);
+
+     if (ballsLeft[currentPlayer] <= 0) return null;
+
+     const newId = (currentPlayer === 'red' ? 100 : 200) + (INITIAL_BALLS_PER_PLAYER - ballsLeft[currentPlayer]);
+     const origin = getThrowOrigin(currentPlayer);
+
+     return { id: newId, x: origin.x, y: origin.y, vx: 0, vy: 0, color: currentPlayer };
+  }, [jackNeedsPlacement, ballsLeft, currentPlayer, getThrowOrigin]);
   
   React.useEffect(() => {
     if ((phase === 'newRound' || phase === 'turnEnd') && aimingPhase === 'idle') {
@@ -214,271 +256,436 @@ export function BocciaGame({ onExit }: { onExit: () => void; }) {
               setPhase('turnEnd');
           } else {
               // Both players have no balls left. End of round simulation.
-              if (phase !== 'simulating' && phase !== 'roundEnd') {
-                calculateRoundScore();
-              }
+              calculateRoundScore();
           }
       }
     }
-  }, [phase, aimingPhase, getBallToPlay, ballsLeft]);
+  }, [phase, aimingPhase, getBallToPlay, ballsLeft, calculateRoundScore]);
 
 
-  const handleClick = (e: React.MouseEvent) => {
-    if (phase !== 'aiming' || !gameAreaRef.current) return;
-  
-    if (aimingPhase === 'idle' && ballToPlay) {
-      const rect = gameAreaRef.current.getBoundingClientRect();
-      const mousePos = { x: e.clientX - rect.left, y: e.clientY - rect.top };
-      const dist = Math.hypot(mousePos.x - ballToPlay.x, mousePos.y - ballToPlay.y);
-      if (dist < BALL_RADIUS) {
-        setAimingPhase('arming');
-      }
-    } else if (aimingPhase === 'arming' && ballToPlay) {
-      const rect = gameAreaRef.current.getBoundingClientRect();
-      const mousePos = { x: e.clientX - rect.left, y: e.clientY - rect.top };
-      
-      const directionVector = { x: mousePos.x - ballToPlay.x, y: mousePos.y - ballToPlay.y };
-      const angle = Math.atan2(directionVector.y, directionVector.x);
-      
-      const velocity = { vx: Math.cos(angle) * power, vy: Math.sin(angle) * power };
-  
-      const wasJackTurn = ballToPlay.color === 'white';
-  
-      setBalls(prev => [...prev, { ...ballToPlay, ...velocity }]);
-  
-      if (!wasJackTurn) {
-        setBallsLeft(prev => ({ ...prev, [ballToPlay.color as Player]: prev[ballToPlay.color as Player] - 1 }));
-      }
-  
-      setPhase('simulating');
+  const getPointerPosition = React.useCallback((clientX: number, clientY: number): Vector | null => {
+    if (!gameAreaRef.current) return null;
+    const rect = gameAreaRef.current.getBoundingClientRect();
+    return { x: clientX - rect.left, y: clientY - rect.top };
+  }, []);
+
+  const updateAimingLine = React.useCallback((target: Vector) => {
+    if (!ballToPlay) return;
+    setAimingLine({ start: { x: ballToPlay.x, y: ballToPlay.y }, end: target });
+    const dragVector = { x: ballToPlay.x - target.x, y: ballToPlay.y - target.y };
+    const dist = Math.hypot(dragVector.x, dragVector.y);
+    setPower(Math.min(dist / 12, MAX_POWER));
+  }, [ballToPlay]);
+
+  const releaseCurrentShot = React.useCallback((target: Vector) => {
+    if (!ballToPlay) return;
+
+    const dragVector = { x: ballToPlay.x - target.x, y: ballToPlay.y - target.y };
+    const dist = Math.hypot(dragVector.x, dragVector.y);
+
+    const shotPower = Math.min(dist / 12, MAX_POWER);
+    if (shotPower < 0.2) {
       setAimingPhase('idle');
-      setBallToPlay(null);
       setAimingLine(null);
       setPower(0);
+      return;
+    }
+
+    const normalized = dist === 0 ? { x: 0, y: 0 } : { x: dragVector.x / dist, y: dragVector.y / dist };
+    const velocity = { vx: normalized.x * shotPower, vy: normalized.y * shotPower };
+
+    const wasJackTurn = ballToPlay.color === 'white';
+    lastThrowerRef.current = wasJackTurn ? currentPlayer : ballToPlay.color as Player;
+
+    setBalls(prev => [...prev, { ...ballToPlay, ...velocity }]);
+
+    if (!wasJackTurn) {
+      setBallsLeft(prev => ({ ...prev, [ballToPlay.color as Player]: prev[ballToPlay.color as Player] - 1 }));
+    }
+
+    setPhase('simulating');
+    setAimingPhase('idle');
+    setBallToPlay(null);
+    setAimingLine(null);
+    setPower(0);
+  }, [ballToPlay, currentPlayer]);
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    if (phase !== 'aiming' || aimingPhase !== 'idle' || !ballToPlay) return;
+
+    const pos = getPointerPosition(e.clientX, e.clientY);
+    if (!pos) return;
+
+    const dist = Math.hypot(pos.x - ballToPlay.x, pos.y - ballToPlay.y);
+    if (dist > BALL_RADIUS * 1.6) return;
+
+    e.preventDefault();
+    activePointerId.current = e.pointerId;
+    gameAreaRef.current?.setPointerCapture(e.pointerId);
+    setAimingPhase('arming');
+    updateAimingLine(pos);
+  };
+
+  const handlePointerMove = (e: React.PointerEvent) => {
+    if (phase !== 'aiming' || aimingPhase !== 'arming' || activePointerId.current !== e.pointerId) return;
+    const pos = getPointerPosition(e.clientX, e.clientY);
+    if (!pos) return;
+    updateAimingLine(pos);
+  };
+
+  const finishAiming = (pointerId: number | null) => {
+    if (pointerId !== null) {
+      try {
+        gameAreaRef.current?.releasePointerCapture(pointerId);
+      } catch {
+        // Ignore release errors (pointer already released)
+      }
+    }
+    activePointerId.current = null;
+  };
+
+  const handlePointerUp = (e: React.PointerEvent) => {
+    if (phase !== 'aiming' || aimingPhase !== 'arming' || activePointerId.current !== e.pointerId) {
+      finishAiming(null);
+      return;
+    }
+
+    const pos = getPointerPosition(e.clientX, e.clientY);
+    if (pos) {
+      releaseCurrentShot(pos);
+    }
+    finishAiming(e.pointerId);
+  };
+
+  const handlePointerCancel = (e: React.PointerEvent) => {
+    if (activePointerId.current !== e.pointerId) return;
+    finishAiming(e.pointerId);
+    setAimingPhase('idle');
+    setAimingLine(null);
+    setPower(0);
+  };
+
+  const handlePointerLeave = (e: React.PointerEvent) => {
+    if (aimingPhase === 'arming' && activePointerId.current === e.pointerId) {
+      handlePointerCancel(e);
     }
   };
-  
-  const handleMouseMove = (e: React.MouseEvent) => {
-    if (phase === 'aiming' && aimingPhase === 'arming' && ballToPlay) {
-        const rect = gameAreaRef.current!.getBoundingClientRect();
-        const mousePos = { x: e.clientX - rect.left, y: e.clientY - rect.top };
-        setAimingLine({start: ballToPlay, end: mousePos});
-        const dist = Math.hypot(mousePos.x - ballToPlay.x, mousePos.y - ballToPlay.y);
-        setPower(Math.min(dist / 10, MAX_POWER));
-    }
-  }
 
   React.useEffect(() => {
     let animationFrameId: number;
-    
+
     const gameLoop = () => {
-        if (phase === 'simulating') {
-            let isMoving = false;
-            setBalls(currentBalls => {
-                const nextBalls = currentBalls.map(ball => {
-                    let newVx = ball.vx * FRICTION;
-                    let newVy = ball.vy * FRICTION;
+      if (phase === 'simulating') {
+        let isMoving = false;
+        setBalls(currentBalls => {
+          const hadJack = currentBalls.some(b => b.color === 'white');
+          const nextBalls = currentBalls.map(ball => {
+            let newVx = ball.vx * FRICTION;
+            let newVy = ball.vy * FRICTION;
 
-                    if (Math.abs(newVx) < MIN_VELOCITY) newVx = 0;
-                    if (Math.abs(newVy) < MIN_VELOCITY) newVy = 0;
+            if (Math.abs(newVx) < MIN_VELOCITY) newVx = 0;
+            if (Math.abs(newVy) < MIN_VELOCITY) newVy = 0;
 
-                    if(newVx !== 0 || newVy !== 0) isMoving = true;
+            if (newVx !== 0 || newVy !== 0) isMoving = true;
 
-                    return { ...ball, vx: newVx, vy: newVy, x: ball.x + newVx, y: ball.y + newVy };
-                });
+            return { ...ball, vx: newVx, vy: newVy, x: ball.x + newVx, y: ball.y + newVy };
+          });
 
-                for (let i = 0; i < nextBalls.length; i++) {
-                    for (let j = i + 1; j < nextBalls.length; j++) {
-                        const b1 = nextBalls[i];
-                        const b2 = nextBalls[j];
-                        const dx = b2.x - b1.x;
-                        const dy = b2.y - b1.y;
-                        const distance = Math.hypot(dx, dy);
+          for (let i = 0; i < nextBalls.length; i++) {
+            for (let j = i + 1; j < nextBalls.length; j++) {
+              const b1 = nextBalls[i];
+              const b2 = nextBalls[j];
+              const dx = b2.x - b1.x;
+              const dy = b2.y - b1.y;
+              const distance = Math.hypot(dx, dy);
 
-                        if (distance < BALL_RADIUS * 2) {
-                            const angle = Math.atan2(dy, dx);
-                            const sin = Math.sin(angle);
-                            const cos = Math.cos(angle);
-                            
-                            const vx1 = b1.vx * cos + b1.vy * sin;
-                            const vy1 = b1.vy * cos - b1.vx * sin;
-                            const vx2 = b2.vx * cos + b2.vy * sin;
-                            const vy2 = b2.vy * cos - b2.vx * sin;
+              if (distance < BALL_RADIUS * 2) {
+                const angle = Math.atan2(dy, dx);
+                const sin = Math.sin(angle);
+                const cos = Math.cos(angle);
 
-                            const vx1Final = vx2;
-                            const vx2Final = vx1;
+                const vx1 = b1.vx * cos + b1.vy * sin;
+                const vy1 = b1.vy * cos - b1.vx * sin;
+                const vx2 = b2.vx * cos + b2.vy * sin;
+                const vy2 = b2.vy * cos - b2.vx * sin;
 
-                            b1.vx = vx1Final * cos - vy1 * sin;
-                            b1.vy = vy1 * cos + vx1Final * sin;
-                            b2.vx = vx2Final * cos - vy2 * sin;
-                            b2.vy = vy2 * cos + vx2Final * sin;
-                            
-                            const overlap = (BALL_RADIUS * 2 - distance) / 2;
-                            b1.x -= overlap * cos;
-                            b1.y -= overlap * sin;
-                            b2.x += overlap * cos;
-                            b2.y += overlap * sin;
-                        }
-                    }
-                    if (nextBalls[i].x < BALL_RADIUS) { nextBalls[i].x = BALL_RADIUS; nextBalls[i].vx *= -0.8; }
-                    if (nextBalls[i].x > GAME_WIDTH - BALL_RADIUS) { nextBalls[i].x = GAME_WIDTH - BALL_RADIUS; nextBalls[i].vx *= -0.8; }
-                    if (nextBalls[i].y < BALL_RADIUS) { nextBalls[i].y = BALL_RADIUS; nextBalls[i].vy *= -0.8; }
-                    if (nextBalls[i].y > TOTAL_HEIGHT - BALL_RADIUS) { 
-                        nextBalls[i].y = TOTAL_HEIGHT - BALL_RADIUS; 
-                        nextBalls[i].vy *= -0.8; 
-                    }
+                const vx1Final = vx2;
+                const vx2Final = vx1;
+
+                b1.vx = vx1Final * cos - vy1 * sin;
+                b1.vy = vy1 * cos + vx1Final * sin;
+                b2.vx = vx2Final * cos - vy2 * sin;
+                b2.vy = vy2 * cos + vx2Final * sin;
+
+                const overlap = (BALL_RADIUS * 2 - distance) / 2;
+                b1.x -= overlap * cos;
+                b1.y -= overlap * sin;
+                b2.x += overlap * cos;
+                b2.y += overlap * sin;
+              }
+            }
+            if (nextBalls[i].x < BALL_RADIUS) { nextBalls[i].x = BALL_RADIUS; nextBalls[i].vx *= -0.8; }
+            if (nextBalls[i].x > totalWidth - BALL_RADIUS) { nextBalls[i].x = totalWidth - BALL_RADIUS; nextBalls[i].vx *= -0.8; }
+            if (nextBalls[i].y < BALL_RADIUS) { nextBalls[i].y = BALL_RADIUS; nextBalls[i].vy *= -0.8; }
+            if (nextBalls[i].y > totalHeight - BALL_RADIUS) {
+              nextBalls[i].y = totalHeight - BALL_RADIUS;
+              nextBalls[i].vy *= -0.8;
+            }
+          }
+
+          if (!isMoving) {
+            const jackBall = nextBalls.find(b => b.color === 'white');
+
+            if (!jackBall || jackBall.x <= fieldStartX || jackBall.x >= totalWidth) {
+              if (jackNeedsPlacement) {
+                if (hadJack) {
+                  toast({
+                    title: 'Jack hors zone',
+                    description: 'Le Jack doit rester sur le terrain. C\'est à l\'autre joueur de le relancer.'
+                  });
+                  setCurrentPlayer(lastThrowerRef.current === 'red' ? 'blue' : 'red');
                 }
-                
-                if (!isMoving) {
-                    if (ballsLeft.red === 0 && ballsLeft.blue === 0) {
-                        calculateRoundScore();
-                    } else {
-                        const nextPlayer = determineNextPlayer();
-                        setCurrentPlayer(nextPlayer);
-                        setPhase('turnEnd');
-                    }
-                }
-                return nextBalls;
-            });
-        }
-        animationFrameId = requestAnimationFrame(gameLoop);
+                setJackNeedsPlacement(true);
+                setPhase('newRound');
+                return nextBalls.filter(b => b.color !== 'white');
+              }
+
+              setRoundWinner(null);
+              setRoundScore({ red: 0, blue: 0 });
+              setNextStartingPlayer(roundStarterRef.current);
+              setPhase('roundEnd');
+              return nextBalls;
+            }
+
+            if (jackNeedsPlacement) {
+              setJackNeedsPlacement(false);
+              roundStarterRef.current = lastThrowerRef.current;
+              setCurrentPlayer(lastThrowerRef.current);
+              setPhase('turnEnd');
+              return nextBalls;
+            }
+
+            if (ballsLeft.red === 0 && ballsLeft.blue === 0) {
+              calculateRoundScore();
+            } else {
+              const nextPlayer = determineNextPlayer(nextBalls, ballsLeft, currentPlayer);
+              setCurrentPlayer(nextPlayer);
+              setPhase('turnEnd');
+            }
+          }
+
+          return nextBalls;
+        });
+      }
+      animationFrameId = requestAnimationFrame(gameLoop);
     };
 
     animationFrameId = requestAnimationFrame(gameLoop);
     return () => cancelAnimationFrame(animationFrameId);
-  }, [phase, determineNextPlayer, ballsLeft]);
+  }, [phase, determineNextPlayer, ballsLeft, jackNeedsPlacement, currentPlayer, calculateRoundScore, toast, fieldStartX, totalHeight, totalWidth]);
   
-  const cursorClass = (phase === 'aiming' && aimingPhase === 'idle' && ballToPlay)
-    ? (ballToPlay.color === 'white' ? 'cursor-[url(/cursors/white.svg),_pointer]' : (ballToPlay.color === 'red' ? 'cursor-[url(/cursors/red.svg),_pointer]' : 'cursor-[url(/cursors/blue.svg),_pointer]'))
-    : (phase === 'aiming' && aimingPhase === 'arming' ? 'cursor-crosshair' : 'cursor-default');
+  const statusMessage = React.useMemo(() => {
+    const playerLabel = currentPlayer === 'red' ? 'Rouge' : 'Bleu';
+
+    if (phase === 'roundEnd') {
+      return 'La manche est terminée.';
+    }
+
+    if (jackNeedsPlacement) {
+      return `Placer le Jack : au joueur ${playerLabel} de jouer.`;
+    }
+
+    if (phase === 'simulating') {
+      return 'Les boules sont encore en mouvement...';
+    }
+
+    if (phase === 'aiming' && aimingPhase === 'arming') {
+      return 'Relâchez pour tirer !';
+    }
+
+    return `Au tour du joueur ${playerLabel}.`;
+  }, [phase, jackNeedsPlacement, currentPlayer, aimingPhase]);
+
+  const pointerColor: Player | null = React.useMemo(() => {
+    if (phase !== 'aiming' || !ballToPlay) return null;
+    if (jackNeedsPlacement || ballToPlay.color === 'white') {
+      return currentPlayer;
+    }
+    return ballToPlay.color as Player;
+  }, [phase, ballToPlay, jackNeedsPlacement, currentPlayer]);
+
+  const cursorClass = React.useMemo(() => {
+    if (phase !== 'aiming' || !ballToPlay) return 'cursor-default';
+    if (aimingPhase === 'arming') return 'cursor-grabbing';
+    if (!pointerColor) return 'cursor-default';
+    return pointerColor === 'red'
+      ? 'cursor-[url(/cursors/red.svg),_pointer]'
+      : 'cursor-[url(/cursors/blue.svg),_pointer]';
+  }, [phase, ballToPlay, aimingPhase, pointerColor]);
 
     
-  const RemainingBalls = ({ player, count }: {player: Player, count: number}) => (
-    <div className="flex flex-col items-center">
-        <div className="flex gap-2 mt-2">
-            {Array.from({ length: count }).map((_, i) => (
-                 <div
-                    key={i}
-                    className={cn("w-6 h-6 rounded-full border-2", {
-                      'bg-red-600 border-red-800': player === 'red',
-                      'bg-blue-600 border-blue-800': player === 'blue',
-                    })}
-                  />
-            ))}
-        </div>
+  const RemainingBalls = ({ player, count }: { player: Player; count: number }) => (
+    <div className="flex gap-2">
+      {Array.from({ length: count }).map((_, i) => (
+        <div
+          key={i}
+          className={cn('h-5 w-5 rounded-full border-2', {
+            'bg-red-600 border-red-800': player === 'red',
+            'bg-blue-600 border-blue-800': player === 'blue',
+          })}
+        />
+      ))}
     </div>
   );
 
+  React.useLayoutEffect(() => {
+    if (!gameAreaRef.current || typeof ResizeObserver === 'undefined') return;
+    const element = gameAreaRef.current;
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        setAreaSize({ width, height });
+      }
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <main className="flex flex-col items-center justify-center h-screen bg-gray-900 text-white">
-      <Card className="w-auto shadow-2xl bg-zinc-800 text-white border-zinc-700">
-        <CardHeader className="flex flex-row items-center justify-between">
-           <CardTitle className="font-headline text-3xl">Boccia</CardTitle>
-           <div className="flex gap-8 items-center">
-             <div className="text-center">
-                <p className={cn("text-lg font-bold text-red-500", (phase !== 'roundEnd' && currentPlayer === 'red') ? 'animate-pulse' : '')}>Joueur Rouge</p>
-                <div className="flex items-center gap-4">
-                  <span>Score: {totalScore.red}</span>
-                  <RemainingBalls player="red" count={ballsLeft.red} />
-                </div>
-             </div>
-              <div className="text-center">
-                <p className={cn("text-lg font-bold text-blue-500", (phase !== 'roundEnd' && currentPlayer === 'blue') ? 'animate-pulse' : '')}>Joueur Bleu</p>
-                <div className="flex items-center gap-4">
-                  <span>Score: {totalScore.blue}</span>
-                   <RemainingBalls player="blue" count={ballsLeft.blue} />
-                </div>
-             </div>
-           </div>
-        </CardHeader>
-        <CardContent>
-          <div
-            ref={gameAreaRef}
-            onClick={handleClick}
-            onMouseMove={handleMouseMove}
-            className={cn("relative border-4 border-yellow-700 rounded-md overflow-hidden", cursorClass)}
-            style={{ width: GAME_WIDTH, height: TOTAL_HEIGHT }}
-          >
-            {/* Main Playing Area */}
-            <div className="absolute top-0 left-0 bg-green-800" style={{width: GAME_WIDTH, height: GAME_HEIGHT }} />
-            
-            {/* Throwing Area */}
-            <div className="absolute bottom-0 left-0 bg-green-900/50" style={{width: GAME_WIDTH, height: THROWING_AREA_HEIGHT }}/>
-
-            {balls.map(ball => (
-              <div
-                key={ball.id}
-                className={cn("absolute rounded-full border-2 shadow-lg", {
-                  'bg-white border-black': ball.color === 'white',
-                  'bg-red-600 border-red-800': ball.color === 'red',
-                  'bg-blue-600 border-blue-800': ball.color === 'blue',
-                })}
-                style={{
-                  width: BALL_RADIUS * 2,
-                  height: BALL_RADIUS * 2,
-                  transform: `translate(${ball.x - BALL_RADIUS}px, ${ball.y - BALL_RADIUS}px)`,
-                  transition: phase === 'simulating' ? 'transform 16ms linear' : 'none'
-                }}
-              />
-            ))}
-            
-            {ballToPlay && (
-                 <div
-                    key={ballToPlay.id}
-                    className={cn("absolute rounded-full border-2 shadow-lg", {
-                    'bg-white border-black': ballToPlay.color === 'white',
-                    'bg-red-600 border-red-800': ballToPlay.color === 'red',
-                    'bg-blue-600 border-blue-800': ballToPlay.color === 'blue',
-                    })}
-                    style={{
-                    width: BALL_RADIUS * 2,
-                    height: BALL_RADIUS * 2,
-                    transform: `translate(${ballToPlay.x - BALL_RADIUS}px, ${ballToPlay.y - BALL_RADIUS}px)`,
-                    }}
-                />
-            )}
-            
-             {aimingPhase === 'arming' && aimingLine && (
-                 <svg className="absolute top-0 left-0 w-full h-full pointer-events-none">
-                    <defs>
-                        <linearGradient id="powerGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-                            <stop offset="0%" style={{stopColor: 'lightgreen', stopOpacity: 1}} />
-                            <stop offset="50%" style={{stopColor: 'yellow', stopOpacity: 1}} />
-                            <stop offset="100%" style={{stopColor: 'red', stopOpacity: 1}} />
-                        </linearGradient>
-                    </defs>
-                    <line x1={aimingLine.start.x} y1={aimingLine.start.y} x2={aimingLine.end.x} y2={aimingLine.end.y} stroke="rgba(255,255,255,0.5)" strokeWidth="2" strokeDasharray="5,5" />
-                 </svg>
-            )}
-
-            {aimingPhase === 'arming' && (
-                <div className="absolute bottom-4 left-1/2 -translate-x-1/2 w-1/2">
-                    <p className="text-center text-sm mb-1">Puissance</p>
-                    <Progress value={ (power / MAX_POWER) * 100 } className="w-full h-4" />
-                </div>
-            )}
-
-
-            {phase === 'roundEnd' && (
-                <div className="absolute inset-0 bg-black/70 flex flex-col items-center justify-center z-10">
-                    <h3 className="text-3xl font-bold">Fin de la manche</h3>
-                     {roundWinner && <p className="text-xl mt-2">{`Le joueur ${roundWinner === 'red' ? 'Rouge' : 'Bleu'} marque ${roundScore[roundWinner]} point(s).`}</p>}
-                     {!roundWinner && <p className="text-xl mt-2">Aucun point marqué.</p>}
-                    <Button onClick={startNewRound} className="mt-6">Manche Suivante</Button>
-                </div>
-            )}
-            
+    <main className="flex h-screen w-screen flex-col bg-gray-900 text-white">
+      <header className="flex flex-col gap-2 border-b border-zinc-800 px-8 py-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="font-headline text-4xl">Boccia</h1>
+            <p className="text-sm text-zinc-300">Manche {roundNumber}</p>
           </div>
-        </CardContent>
-        <CardContent className="flex justify-between">
-             <Button onClick={onExit}>
-                <ArrowLeft className="mr-2" /> Quitter
-            </Button>
-            <Button onClick={resetGame} variant="secondary">
-                <RefreshCw className="mr-2" /> Recommencer la partie
-            </Button>
-        </CardContent>
-      </Card>
+          <div className="flex items-start gap-8">
+            <div className="text-right">
+              <p
+                className={cn(
+                  'text-lg font-bold text-red-400',
+                  phase !== 'roundEnd' && currentPlayer === 'red' ? 'animate-pulse' : ''
+                )}
+              >
+                Joueur Rouge
+              </p>
+              <div className="mt-1 flex items-center justify-end gap-4 text-sm">
+                <span>Score : {totalScore.red}</span>
+                <RemainingBalls player="red" count={ballsLeft.red} />
+              </div>
+            </div>
+            <div className="text-right">
+              <p
+                className={cn(
+                  'text-lg font-bold text-blue-400',
+                  phase !== 'roundEnd' && currentPlayer === 'blue' ? 'animate-pulse' : ''
+                )}
+              >
+                Joueur Bleu
+              </p>
+              <div className="mt-1 flex items-center justify-end gap-4 text-sm">
+                <span>Score : {totalScore.blue}</span>
+                <RemainingBalls player="blue" count={ballsLeft.blue} />
+              </div>
+            </div>
+          </div>
+        </div>
+        <p className="text-sm text-zinc-400">{statusMessage}</p>
+      </header>
+      <div className="flex flex-1 flex-col gap-6 px-8 pb-8">
+        <div
+          ref={gameAreaRef}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerCancel}
+          onPointerLeave={handlePointerLeave}
+          className={cn(
+            'relative flex-1 overflow-hidden rounded-xl border-4 border-yellow-700 bg-zinc-800 shadow-2xl touch-none',
+            cursorClass
+          )}
+        >
+          <div className="absolute inset-y-0 left-0" style={{ width: throwAreaWidth }}>
+            <div className="h-full w-full bg-emerald-900/70" />
+          </div>
+          <div className="absolute inset-y-0" style={{ left: throwAreaWidth, right: 0 }}>
+            <div className="h-full w-full bg-emerald-800" />
+          </div>
+
+          {balls.map(ball => (
+            <div
+              key={ball.id}
+              className={cn('absolute rounded-full border-2 shadow-lg', {
+                'bg-white border-black': ball.color === 'white',
+                'bg-red-600 border-red-800': ball.color === 'red',
+                'bg-blue-600 border-blue-800': ball.color === 'blue',
+              })}
+              style={{
+                width: BALL_RADIUS * 2,
+                height: BALL_RADIUS * 2,
+                transform: `translate(${ball.x - BALL_RADIUS}px, ${ball.y - BALL_RADIUS}px)`,
+                transition: phase === 'simulating' ? 'transform 16ms linear' : 'none'
+              }}
+            />
+          ))}
+
+          {ballToPlay && (
+            <div
+              key={ballToPlay.id}
+              className={cn('absolute rounded-full border-2 shadow-lg', {
+                'bg-white border-black': ballToPlay.color === 'white',
+                'bg-red-600 border-red-800': ballToPlay.color === 'red',
+                'bg-blue-600 border-blue-800': ballToPlay.color === 'blue',
+              })}
+              style={{
+                width: BALL_RADIUS * 2,
+                height: BALL_RADIUS * 2,
+                transform: `translate(${ballToPlay.x - BALL_RADIUS}px, ${ballToPlay.y - BALL_RADIUS}px)`,
+              }}
+            />
+          )}
+
+          {aimingPhase === 'arming' && aimingLine && (
+            <svg className="absolute inset-0 h-full w-full pointer-events-none">
+              <line
+                x1={aimingLine.start.x}
+                y1={aimingLine.start.y}
+                x2={aimingLine.end.x}
+                y2={aimingLine.end.y}
+                stroke="rgba(255,255,255,0.5)"
+                strokeWidth="2"
+                strokeDasharray="5,5"
+              />
+            </svg>
+          )}
+
+          {aimingPhase === 'arming' && (
+            <div className="absolute bottom-6 left-1/2 w-1/2 -translate-x-1/2">
+              <p className="mb-1 text-center text-sm">Puissance</p>
+              <Progress value={(power / MAX_POWER) * 100} className="h-4 w-full" />
+            </div>
+          )}
+
+          {phase === 'roundEnd' && (
+            <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-black/70">
+              <h3 className="text-3xl font-bold">Fin de la manche</h3>
+              {roundWinner && (
+                <p className="mt-2 text-xl">{`Le joueur ${roundWinner === 'red' ? 'Rouge' : 'Bleu'} marque ${roundScore[roundWinner]} point(s).`}</p>
+              )}
+              {!roundWinner && <p className="mt-2 text-xl">Aucun point marqué.</p>}
+              <Button onClick={() => startNewRound()} className="mt-6">Manche suivante</Button>
+            </div>
+          )}
+        </div>
+        <div className="flex justify-between gap-4">
+          <Button onClick={onExit}>
+            <ArrowLeft className="mr-2" /> Quitter
+          </Button>
+          <Button onClick={resetGame} variant="secondary">
+            <RefreshCw className="mr-2" /> Recommencer la partie
+          </Button>
+        </div>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- réorganise la surface de jeu de boccia en plein écran avec une zone de lancer à gauche, un terrain à droite et un dimensionnement dynamique
- affiche en permanence les scores, le numéro de manche et ajuste le pointeur pour indiquer quel joueur doit lancer le jack
- empêche les boules de sortir des limites grâce à des contrôles de collisions alignés sur le nouveau terrain horizontal

## Testing
- npm run typecheck *(échoue : erreurs préexistantes sur plusieurs composants et imports d’images manquantes)*

------
https://chatgpt.com/codex/tasks/task_e_68d857c0ec048325915c8bc3f531a247