### PR TITLE
Add messenger-style student chat with notifications

### DIFF
--- a/src/app/en-classe/page.tsx
+++ b/src/app/en-classe/page.tsx
@@ -15,6 +15,7 @@ import { FullscreenToggle } from '@/components/fullscreen-toggle';
 import { getScoresForUser } from '@/services/scores';
 import { isToday } from 'date-fns';
 import { cn } from '@/lib/utils';
+import { ChatLauncher } from '@/components/chat/chat-launcher';
 
 export default function EnClassePage() {
   const { student, isLoading: isUserLoading } = useContext(UserContext);
@@ -114,7 +115,7 @@ export default function EnClassePage() {
 
   return (
     <main className="container mx-auto px-4 py-8">
-       <header className="mb-12 text-center space-y-4 relative">
+      <header className="mb-12 text-center space-y-4 relative">
         <div className="absolute top-0 left-0 flex items-center gap-2">
              <Button asChild variant="outline" size="sm">
                 <Link href="/">
@@ -189,6 +190,7 @@ export default function EnClassePage() {
             <p className="text-muted-foreground mt-2">Ton enseignant n'a pas encore activé d'exercices pour le mode "En classe".</p>
         </Card>
       )}
+      <ChatLauncher />
     </main>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,9 @@
 import './globals.css';
 import { Toaster } from "@/components/ui/toaster";
 import { UserProvider } from '@/context/user-context';
+import { ChatProvider } from '@/context/chat-context';
+import { ChatOverlay } from '@/components/chat/chat-overlay';
+import { ChatNotifications } from '@/components/chat/chat-notifications';
 
 export default function RootLayout({
   children,
@@ -12,16 +15,20 @@ export default function RootLayout({
 }>) {
   return (
     <UserProvider>
-      <html lang="fr">
-        <head>
-          <title>Classe Magique</title>
-          <meta name="description" content="Des exercices amusants et engageants pour développer vos compétences !" />
-        </head>
-        <body className="font-body antialiased">
-          {children}
-          <Toaster />
-        </body>
-      </html>
+      <ChatProvider>
+        <html lang="fr">
+          <head>
+            <title>Classe Magique</title>
+            <meta name="description" content="Des exercices amusants et engageants pour développer vos compétences !" />
+          </head>
+          <body className="font-body antialiased">
+            {children}
+            <ChatOverlay />
+            <ChatNotifications />
+            <Toaster />
+          </body>
+        </html>
+      </ChatProvider>
     </UserProvider>
   );
 }

--- a/src/components/chat/chat-launcher.tsx
+++ b/src/components/chat/chat-launcher.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { MessageCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useChat } from '@/context/chat-context';
+import { useContext, useEffect } from 'react';
+import { UserContext } from '@/context/user-context';
+
+export function ChatLauncher() {
+  const { student } = useContext(UserContext);
+  const { toggleChat, unreadTotal, pendingConversationId, openConversationById, setPendingConversation } = useChat();
+
+  useEffect(() => {
+    if (!pendingConversationId) return;
+    if (!student?.id) return;
+    openConversationById(pendingConversationId).then(() => {
+      setPendingConversation(null);
+    });
+  }, [pendingConversationId, openConversationById, student?.id, setPendingConversation]);
+
+  if (!student) return null;
+
+  return (
+    <Button
+      aria-label="Ouvrir la messagerie"
+      className="fixed bottom-6 right-6 z-[120] h-14 w-14 rounded-full shadow-lg"
+      onClick={toggleChat}
+      size="icon"
+    >
+      <MessageCircle className="h-6 w-6" />
+      {unreadTotal > 0 && (
+        <span className="absolute -top-2 -right-2 flex h-6 w-6 items-center justify-center rounded-full bg-red-500 text-xs font-bold text-white">
+          {unreadTotal}
+        </span>
+      )}
+    </Button>
+  );
+}

--- a/src/components/chat/chat-notifications.tsx
+++ b/src/components/chat/chat-notifications.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
+import { Bell } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useChat } from '@/context/chat-context';
+
+function formatRelative(date: Date | null): string {
+  if (!date) return '';
+  const formatter = new Intl.DateTimeFormat('fr-FR', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  return formatter.format(date);
+}
+
+export function ChatNotifications() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { notifications, unreadTotal, setPendingConversation, openConversationById } = useChat();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleToggle = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  const handleOpenConversation = (conversationId: string) => {
+    setIsOpen(false);
+    setPendingConversation(conversationId);
+    if (pathname === '/en-classe') {
+      void openConversationById(conversationId);
+    } else {
+      router.push('/en-classe');
+    }
+  };
+
+  const hasNotifications = notifications.length > 0;
+
+  return (
+    <div className="pointer-events-none fixed top-4 right-4 z-[160]">
+      <div className="pointer-events-auto">
+        <Button
+          aria-label="Notifications de messagerie"
+          onClick={handleToggle}
+          size="icon"
+          variant="outline"
+          className="relative"
+        >
+          <Bell className="h-5 w-5" />
+          {unreadTotal > 0 && (
+            <span className="absolute -top-2 -right-2 flex h-5 min-w-[1.1rem] items-center justify-center rounded-full bg-red-500 px-[3px] text-[10px] font-semibold text-white">
+              {unreadTotal}
+            </span>
+          )}
+        </Button>
+        {isOpen && (
+          <Card className="mt-2 w-80 shadow-xl">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base font-semibold">Nouveaux messages</CardTitle>
+            </CardHeader>
+            <CardContent className="max-h-80 space-y-2 overflow-y-auto p-2">
+              {hasNotifications ? (
+                notifications.map((notification) => (
+                  <button
+                    key={notification.conversationId}
+                    className="w-full rounded-lg border border-transparent px-3 py-2 text-left transition hover:border-primary/40 hover:bg-primary/5"
+                    onClick={() => handleOpenConversation(notification.conversationId)}
+                    type="button"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-semibold">{notification.contactName}</span>
+                      <span className="text-xs text-muted-foreground">{formatRelative(notification.updatedAt)}</span>
+                    </div>
+                    <div className="mt-1 flex items-center gap-2">
+                      <span className="inline-flex min-w-[1.5rem] justify-center rounded-full bg-red-500 px-2 text-[11px] font-bold text-white">
+                        {notification.unreadCount}
+                      </span>
+                      <span className="line-clamp-2 text-xs text-muted-foreground">{notification.preview}</span>
+                    </div>
+                  </button>
+                ))
+              ) : (
+                <p className="px-1 py-6 text-center text-sm text-muted-foreground">Aucune nouvelle notification.</p>
+              )}
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/chat-overlay.tsx
+++ b/src/components/chat/chat-overlay.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useChat } from '@/context/chat-context';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { UserContext } from '@/context/user-context';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import { X } from 'lucide-react';
+
+function formatTime(date: Date | null): string {
+  if (!date) return '';
+  return new Intl.DateTimeFormat('fr-FR', {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function formatRelative(date: Date | null): string {
+  if (!date) return '';
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const oneDay = 24 * 60 * 60 * 1000;
+  if (diff < oneDay) {
+    return formatTime(date);
+  }
+  return new Intl.DateTimeFormat('fr-FR', {
+    day: '2-digit',
+    month: '2-digit',
+  }).format(date);
+}
+
+export function ChatOverlay() {
+  const pathname = usePathname();
+  const { student } = useContext(UserContext);
+  const {
+    isChatOpen,
+    closeChat,
+    conversations,
+    activeConversationId,
+    openConversationByContact,
+    openConversationById,
+    conversationMessages,
+    sendMessage,
+  } = useChat();
+  const [message, setMessage] = useState('');
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!isChatOpen) {
+      setMessage('');
+    }
+  }, [isChatOpen]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [conversationMessages]);
+
+  useEffect(() => {
+    if (!isChatOpen) return;
+    if (activeConversationId) return;
+    if (conversations.length === 0) return;
+    openConversationById(conversations[0].id);
+  }, [isChatOpen, conversations, activeConversationId, openConversationById]);
+
+  const activeConversation = useMemo(() => {
+    return conversations.find((conversation) => conversation.id === activeConversationId) ?? null;
+  }, [conversations, activeConversationId]);
+
+  const contactName = useMemo(() => {
+    if (!student || !activeConversation) return '';
+    const otherId = activeConversation.participantIds.find((id) => id !== student.id);
+    if (!otherId) return '';
+    const details = activeConversation.participantDetails?.[otherId];
+    return details?.name ?? 'Élève';
+  }, [activeConversation, student]);
+
+  const handleSendMessage = async () => {
+    if (!activeConversation) return;
+    const currentMessage = message;
+    setMessage('');
+    await sendMessage(activeConversation.id, currentMessage);
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    void handleSendMessage();
+  };
+
+  if (!student) return null;
+  if (pathname !== '/en-classe') return null;
+  if (!isChatOpen) return null;
+
+  return (
+    <div className="pointer-events-none fixed bottom-24 right-6 z-[150] flex flex-col gap-4 lg:flex-row">
+      <Card className="pointer-events-auto w-72 shadow-xl">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-lg font-semibold">Conversations</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-1 overflow-y-auto p-0">
+          {conversations.map((conversation) => {
+            const otherId = conversation.participantIds.find((id) => id !== student.id);
+            const details = otherId ? conversation.participantDetails?.[otherId] : undefined;
+            const name = details?.name ?? 'Élève';
+            const isActive = activeConversationId === conversation.id;
+            const unread = conversation.unreadCounts?.[student.id] ?? 0;
+            const preview = conversation.lastMessage?.text ?? 'Commencer une discussion';
+            const handleOpen = () => {
+              if (otherId) {
+                void openConversationByContact(otherId);
+              } else {
+                void openConversationById(conversation.id);
+              }
+            };
+            return (
+              <button
+                key={conversation.id}
+                className={cn(
+                  'flex w-full items-start gap-2 px-4 py-3 text-left transition-colors hover:bg-muted',
+                  isActive && 'bg-muted'
+                )}
+                onClick={handleOpen}
+                type="button"
+              >
+                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-bold uppercase text-primary">
+                  {name.slice(0, 2)}
+                </div>
+                <div className="flex-1">
+                  <div className="flex items-center justify-between">
+                    <span className="font-semibold">{name}</span>
+                    <span className="text-xs text-muted-foreground">{formatRelative(conversation.updatedAt ?? null)}</span>
+                  </div>
+                  <p className="line-clamp-1 text-sm text-muted-foreground">{preview}</p>
+                </div>
+                {unread > 0 && (
+                  <span className="ml-2 flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-red-500 px-1 text-xs font-bold text-white">
+                    {unread}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+          {conversations.length === 0 && (
+            <div className="px-4 py-6 text-center text-sm text-muted-foreground">
+              Commence une conversation avec un camarade !
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="pointer-events-auto w-[22rem] shadow-xl lg:w-[26rem]">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 border-b px-4 py-3">
+          <CardTitle className="text-lg font-semibold">{contactName || 'Messagerie'}</CardTitle>
+          <Button variant="ghost" size="icon" onClick={closeChat} aria-label="Fermer la messagerie">
+            <X className="h-5 w-5" />
+          </Button>
+        </CardHeader>
+        <CardContent className="flex h-96 flex-col gap-3 p-4">
+          <div className="flex-1 space-y-2 overflow-y-auto pr-2">
+            {conversationMessages.length === 0 && (
+              <div className="text-center text-sm text-muted-foreground">Dis bonjour à {contactName || 'ton camarade'} !</div>
+            )}
+            {conversationMessages.map((messageItem) => {
+              const isOwn = messageItem.senderId === student.id;
+              return (
+                <div key={messageItem.id} className="flex flex-col">
+                  <div className={cn('max-w-[80%] rounded-2xl px-3 py-2 text-sm shadow', isOwn ? 'self-end bg-primary text-primary-foreground' : 'self-start bg-muted')}>
+                    {messageItem.text}
+                  </div>
+                  <span className={cn('mt-1 text-[10px]', isOwn ? 'self-end text-primary/70' : 'self-start text-muted-foreground')}>{formatTime(messageItem.createdAt)}</span>
+                </div>
+              );
+            })}
+            <div ref={bottomRef} />
+          </div>
+          <form onSubmit={handleSubmit} className="flex gap-2">
+            <Input
+              aria-label="Votre message"
+              autoFocus
+              onChange={(event) => setMessage(event.target.value)}
+              placeholder={`Message à ${contactName || 'ton camarade'}...`}
+              value={message}
+            />
+            <Button type="submit" disabled={!message.trim()}>
+              Envoyer
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/context/chat-context.tsx
+++ b/src/context/chat-context.tsx
@@ -1,0 +1,406 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { UserContext } from './user-context';
+import type { ChatContact, ChatConversationSnapshot, ChatMessage, ChatNotificationItem } from '@/types/chat';
+import {
+  Timestamp,
+  addDoc,
+  collection,
+  doc,
+  increment,
+  onSnapshot,
+  orderBy,
+  query,
+  setDoc,
+  updateDoc,
+  where,
+  type Unsubscribe,
+} from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+
+interface ChatContextValue {
+  contacts: ChatContact[];
+  isChatOpen: boolean;
+  activeConversationId: string | null;
+  conversations: ChatConversationSnapshot[];
+  conversationMessages: ChatMessage[];
+  notifications: ChatNotificationItem[];
+  unreadTotal: number;
+  pendingConversationId: string | null;
+  toggleChat: () => void;
+  closeChat: () => void;
+  openConversationByContact: (contactId: string) => Promise<void>;
+  openConversationById: (conversationId: string) => Promise<void>;
+  setPendingConversation: (conversationId: string | null) => void;
+  sendMessage: (conversationId: string, text: string) => Promise<void>;
+}
+
+export const ChatContext = createContext<ChatContextValue | undefined>(undefined);
+
+function getConversationId(a: string, b: string): string {
+  return [a, b].sort().join('__');
+}
+
+function conversationIdToParticipants(conversationId: string): string[] {
+  return conversationId.split('__');
+}
+
+export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { student } = useContext(UserContext);
+  const [contacts, setContacts] = useState<ChatContact[]>([]);
+  const [conversations, setConversations] = useState<Record<string, ChatConversationSnapshot>>({});
+  const [activeConversationId, setActiveConversationId] = useState<string | null>(null);
+  const [isChatOpen, setIsChatOpen] = useState(false);
+  const [messagesByConversation, setMessagesByConversation] = useState<Record<string, ChatMessage[]>>({});
+  const [pendingConversationId, setPendingConversationId] = useState<string | null>(null);
+  const messagesUnsubRef = useRef<Unsubscribe | null>(null);
+
+  useEffect(() => {
+    if (!student?.id) {
+      setContacts([]);
+      return;
+    }
+
+    const studentsRef = collection(db, 'students');
+    const unsubscribe = onSnapshot(studentsRef, (snapshot) => {
+      const list: ChatContact[] = snapshot.docs
+        .filter((doc) => doc.id !== student.id)
+        .map((doc) => {
+          const data = doc.data() as { name?: string };
+          return {
+            id: doc.id,
+            name: data.name ?? 'Élève',
+          };
+        })
+        .sort((a, b) => a.name.localeCompare(b.name));
+      setContacts(list);
+    });
+
+    return () => unsubscribe();
+  }, [student?.id]);
+
+  useEffect(() => {
+    if (!student?.id) {
+      setConversations({});
+      return;
+    }
+
+    const conversationsRef = collection(db, 'conversations');
+    const conversationsQuery = query(conversationsRef, where('participantIds', 'array-contains', student.id));
+
+    const unsubscribe = onSnapshot(conversationsQuery, (snapshot) => {
+      const mapped: Record<string, ChatConversationSnapshot> = {};
+      snapshot.docs.forEach((doc) => {
+        const data = doc.data() as any;
+        const conversation: ChatConversationSnapshot = {
+          id: doc.id,
+          participantIds: Array.isArray(data.participantIds) ? data.participantIds : [],
+          participantDetails: data.participantDetails ?? {},
+          unreadCounts: data.unreadCounts ?? {},
+          lastMessage: data.lastMessage
+            ? {
+                text: data.lastMessage.text ?? '',
+                senderId: data.lastMessage.senderId ?? '',
+                createdAt: data.lastMessage.createdAt?.toDate?.() ?? null,
+              }
+            : null,
+          updatedAt: data.updatedAt?.toDate?.() ?? null,
+        };
+        mapped[conversation.id] = conversation;
+      });
+      setConversations(mapped);
+    });
+
+    return () => unsubscribe();
+  }, [student?.id]);
+
+  const conversationMessages = useMemo(() => {
+    if (!activeConversationId) return [];
+    return messagesByConversation[activeConversationId] ?? [];
+  }, [activeConversationId, messagesByConversation]);
+
+  useEffect(() => {
+    if (!student?.id || !activeConversationId) {
+      if (messagesUnsubRef.current) {
+        messagesUnsubRef.current();
+        messagesUnsubRef.current = null;
+      }
+      return;
+    }
+
+    if (messagesUnsubRef.current) {
+      messagesUnsubRef.current();
+      messagesUnsubRef.current = null;
+    }
+
+    const messagesRef = collection(db, 'conversations', activeConversationId, 'messages');
+    const messagesQuery = query(messagesRef, orderBy('createdAt', 'asc'));
+    const unsubscribe = onSnapshot(messagesQuery, (snapshot) => {
+      const list: ChatMessage[] = snapshot.docs.map((doc) => {
+        const data = doc.data() as any;
+        return {
+          id: doc.id,
+          conversationId: activeConversationId,
+          senderId: data.senderId ?? '',
+          text: data.text ?? '',
+          createdAt: data.createdAt?.toDate?.() ?? new Date(),
+        };
+      });
+      setMessagesByConversation((prev) => ({
+        ...prev,
+        [activeConversationId]: list,
+      }));
+    });
+    messagesUnsubRef.current = unsubscribe;
+
+    const conversationRef = doc(db, 'conversations', activeConversationId);
+    updateDoc(conversationRef, {
+      [`unreadCounts.${student.id}`]: 0,
+    }).catch(() => {
+      // noop
+    });
+
+    return () => {
+      unsubscribe();
+      messagesUnsubRef.current = null;
+    };
+  }, [activeConversationId, student?.id]);
+
+  const toggleChat = useCallback(() => {
+    setIsChatOpen((prev) => !prev);
+  }, []);
+
+  const closeChat = useCallback(() => {
+    setIsChatOpen(false);
+  }, []);
+
+  const ensureConversationExists = useCallback(
+    async (contactId: string): Promise<string | null> => {
+      if (!student?.id) return null;
+      const contact = contacts.find((c) => c.id === contactId);
+      if (!contact) return null;
+      const conversationId = getConversationId(student.id, contactId);
+      const conversationRef = doc(db, 'conversations', conversationId);
+      const payload: Record<string, any> = {
+        participantIds: [student.id, contactId].sort(),
+        participantDetails: {
+          [student.id]: { name: student.name },
+          [contactId]: { name: contact.name },
+        },
+        unreadCounts: {
+          [student.id]: 0,
+          [contactId]: 0,
+        },
+      };
+      await setDoc(conversationRef, payload, { merge: true });
+      return conversationId;
+    },
+    [contacts, student?.id, student?.name],
+  );
+
+  const openConversationByContact = useCallback(
+    async (contactId: string) => {
+      if (!student?.id) return;
+      const conversationId = await ensureConversationExists(contactId);
+      if (!conversationId) return;
+      setActiveConversationId(conversationId);
+      setIsChatOpen(true);
+      setPendingConversationId(null);
+    },
+    [ensureConversationExists, student?.id],
+  );
+
+  const openConversationById = useCallback(
+    async (conversationId: string) => {
+      if (!student?.id) return;
+      const participantIds = conversationIdToParticipants(conversationId);
+      const otherParticipant = participantIds.find((id) => id !== student.id);
+      if (otherParticipant && !contacts.find((c) => c.id === otherParticipant)) {
+        // Ensure we have basic participant info even if student snapshot did not arrive yet
+        const conversationRef = doc(db, 'conversations', conversationId);
+        await setDoc(
+          conversationRef,
+          {
+            participantDetails: {
+              [student.id]: { name: student.name },
+            },
+          },
+          { merge: true },
+        );
+      }
+      setActiveConversationId(conversationId);
+      setIsChatOpen(true);
+      setPendingConversationId(null);
+    },
+    [contacts, student?.id, student?.name],
+  );
+
+  const sendMessage = useCallback(
+    async (conversationId: string, text: string) => {
+      if (!student?.id) return;
+      const trimmed = text.trim();
+      if (!trimmed) return;
+
+      const participantIdsSource =
+        conversations[conversationId]?.participantIds ?? conversationIdToParticipants(conversationId);
+      const participantIds = [...participantIdsSource].sort();
+      const otherParticipants = participantIds.filter((id) => id !== student.id);
+
+      const conversationRef = doc(db, 'conversations', conversationId);
+      const createdAt = Timestamp.now();
+
+      const contactDetails: Record<string, any> = {
+        [student.id]: { name: student.name },
+      };
+      otherParticipants.forEach((id) => {
+        const contact = contacts.find((c) => c.id === id);
+        if (contact) {
+          contactDetails[id] = { name: contact.name };
+        }
+      });
+
+      await setDoc(
+        conversationRef,
+        {
+          participantIds,
+          participantDetails: contactDetails,
+        },
+        { merge: true },
+      );
+
+      const messagesRef = collection(conversationRef, 'messages');
+      await addDoc(messagesRef, {
+        senderId: student.id,
+        text: trimmed,
+        createdAt,
+        readBy: [student.id],
+      });
+
+      const updates: Record<string, any> = {
+        lastMessage: {
+          text: trimmed,
+          senderId: student.id,
+          createdAt,
+        },
+        updatedAt: createdAt,
+      };
+      updates[`unreadCounts.${student.id}`] = 0;
+      otherParticipants.forEach((id) => {
+        updates[`unreadCounts.${id}`] = increment(1);
+      });
+
+      await setDoc(conversationRef, updates, { merge: true });
+    },
+    [conversations, contacts, student?.id, student?.name],
+  );
+
+  const unreadTotal = useMemo(() => {
+    if (!student?.id) return 0;
+    return Object.values(conversations).reduce((sum, conversation) => {
+      const unread = conversation.unreadCounts?.[student.id] ?? 0;
+      return sum + (typeof unread === 'number' ? unread : 0);
+    }, 0);
+  }, [conversations, student?.id]);
+
+  const conversationList = useMemo(() => {
+    if (!student?.id) return [] as ChatConversationSnapshot[];
+    const map = new Map<string, ChatConversationSnapshot>();
+    Object.values(conversations).forEach((conversation) => {
+      map.set(conversation.id, conversation);
+    });
+
+    const result: ChatConversationSnapshot[] = contacts.map((contact) => {
+      const conversationId = getConversationId(student.id, contact.id);
+      const snapshot = map.get(conversationId);
+      if (snapshot) {
+        return snapshot;
+      }
+      return {
+        id: conversationId,
+        participantIds: [student.id, contact.id],
+        participantDetails: {
+          [student.id]: { name: student.name },
+          [contact.id]: { name: contact.name },
+        },
+        unreadCounts: {
+          [student.id]: 0,
+          [contact.id]: 0,
+        },
+        lastMessage: null,
+        updatedAt: null,
+      };
+    });
+
+    return result.sort((a, b) => {
+      const aTime = a.updatedAt?.getTime?.() ?? 0;
+      const bTime = b.updatedAt?.getTime?.() ?? 0;
+      if (aTime === bTime) {
+        const aOtherId = a.participantIds.find((id) => id !== student.id) ?? '';
+        const bOtherId = b.participantIds.find((id) => id !== student.id) ?? '';
+        const aName = contacts.find((c) => c.id === aOtherId)?.name ?? '';
+        const bName = contacts.find((c) => c.id === bOtherId)?.name ?? '';
+        return aName.localeCompare(bName);
+      }
+      return bTime - aTime;
+    });
+  }, [contacts, conversations, student?.id, student?.name]);
+
+  const notifications = useMemo(() => {
+    if (!student?.id) return [];
+    const items: ChatNotificationItem[] = [];
+    conversationList.forEach((conversation) => {
+      const unread = conversation.unreadCounts?.[student.id] ?? 0;
+      if (!unread) return;
+      const otherId = conversation.participantIds.find((id) => id !== student.id);
+      if (!otherId) return;
+      const contact = contacts.find((c) => c.id === otherId);
+      const contactName = contact?.name ?? conversation.participantDetails?.[otherId]?.name ?? 'Élève';
+      const previewSource = conversation.lastMessage?.text ?? 'Nouveau message';
+      items.push({
+        conversationId: conversation.id,
+        contactId: otherId,
+        contactName,
+        preview: previewSource,
+        unreadCount: unread,
+        updatedAt: conversation.updatedAt ?? null,
+      });
+    });
+    return items.sort((a, b) => {
+      const aTime = a.updatedAt?.getTime?.() ?? 0;
+      const bTime = b.updatedAt?.getTime?.() ?? 0;
+      return bTime - aTime;
+    });
+  }, [conversationList, contacts, student?.id]);
+
+  const value: ChatContextValue = {
+    contacts,
+    isChatOpen,
+    activeConversationId,
+    conversations: conversationList,
+    conversationMessages,
+    notifications,
+    unreadTotal,
+    pendingConversationId,
+    toggleChat,
+    closeChat,
+    openConversationByContact,
+    openConversationById,
+    setPendingConversation: setPendingConversationId,
+    sendMessage,
+  };
+
+  return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>;
+};
+
+export function useChat(): ChatContextValue {
+  const context = useContext(ChatContext);
+  if (!context) {
+    throw new Error('useChat must be used within a ChatProvider');
+  }
+  return context;
+}
+
+export function getConversationIdForParticipants(selfId: string, otherId: string): string {
+  return getConversationId(selfId, otherId);
+}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,0 +1,34 @@
+export interface ChatContact {
+  id: string;
+  name: string;
+}
+
+export interface ChatMessage {
+  id: string;
+  conversationId: string;
+  senderId: string;
+  text: string;
+  createdAt: Date;
+}
+
+export interface ChatConversationSnapshot {
+  id: string;
+  participantIds: string[];
+  participantDetails: Record<string, { name: string }>;
+  unreadCounts: Record<string, number>;
+  lastMessage?: {
+    text: string;
+    senderId: string;
+    createdAt: Date | null;
+  } | null;
+  updatedAt?: Date | null;
+}
+
+export interface ChatNotificationItem {
+  conversationId: string;
+  contactId: string;
+  contactName: string;
+  preview: string;
+  unreadCount: number;
+  updatedAt: Date | null;
+}


### PR DESCRIPTION
## Summary
- add a chat context that syncs contacts, conversations, unread counts, and message sending with Firestore
- create floating messenger UI with launcher, conversation list, and notification center overlays
- wire the chat provider into the app layout so the chat is available on "En classe" with unread badges and notifications everywhere

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d9288b9cec832588bd407df8ce2e2e