### PR TITLE
Improve chat word suggestions with prefix dictionary

### DIFF
--- a/src/data/dictionaries/fr-common-words.ts
+++ b/src/data/dictionaries/fr-common-words.ts
@@ -1,0 +1,2410 @@
+// Auto-generated list of common French words with frequency ranks.
+// Source: hermitdave/FrequencyWords (top 600 words from fr_50k.txt).
+
+export interface FrenchWordEntry {
+  word: string;
+  frequency: number;
+}
+
+export const COMMON_FRENCH_WORDS: FrenchWordEntry[] = [
+  {
+    "word": "de",
+    "frequency": 8435682
+  },
+  {
+    "word": "je",
+    "frequency": 8308698
+  },
+  {
+    "word": "est",
+    "frequency": 6942248
+  },
+  {
+    "word": "pas",
+    "frequency": 5833676
+  },
+  {
+    "word": "le",
+    "frequency": 5305591
+  },
+  {
+    "word": "que",
+    "frequency": 5083052
+  },
+  {
+    "word": "la",
+    "frequency": 4825603
+  },
+  {
+    "word": "vous",
+    "frequency": 4500162
+  },
+  {
+    "word": "tu",
+    "frequency": 4434920
+  },
+  {
+    "word": "un",
+    "frequency": 4360896
+  },
+  {
+    "word": "c'",
+    "frequency": 4184576
+  },
+  {
+    "word": "à",
+    "frequency": 4119959
+  },
+  {
+    "word": "et",
+    "frequency": 4110855
+  },
+  {
+    "word": "il",
+    "frequency": 4025241
+  },
+  {
+    "word": "a",
+    "frequency": 3679682
+  },
+  {
+    "word": "l'",
+    "frequency": 3675406
+  },
+  {
+    "word": "ne",
+    "frequency": 3343288
+  },
+  {
+    "word": "les",
+    "frequency": 3046663
+  },
+  {
+    "word": "j'",
+    "frequency": 2981242
+  },
+  {
+    "word": "en",
+    "frequency": 2925411
+  },
+  {
+    "word": "on",
+    "frequency": 2756346
+  },
+  {
+    "word": "ça",
+    "frequency": 2742676
+  },
+  {
+    "word": "une",
+    "frequency": 2717481
+  },
+  {
+    "word": "d'",
+    "frequency": 2603041
+  },
+  {
+    "word": "ce",
+    "frequency": 2533544
+  },
+  {
+    "word": "qu'",
+    "frequency": 2520219
+  },
+  {
+    "word": "pour",
+    "frequency": 2475533
+  },
+  {
+    "word": "ai",
+    "frequency": 2437065
+  },
+  {
+    "word": "n'",
+    "frequency": 2300252
+  },
+  {
+    "word": "des",
+    "frequency": 1902327
+  },
+  {
+    "word": "qui",
+    "frequency": 1665879
+  },
+  {
+    "word": "mais",
+    "frequency": 1641141
+  },
+  {
+    "word": "dans",
+    "frequency": 1508883
+  },
+  {
+    "word": "nous",
+    "frequency": 1504467
+  },
+  {
+    "word": "elle",
+    "frequency": 1476885
+  },
+  {
+    "word": "me",
+    "frequency": 1446772
+  },
+  {
+    "word": "bien",
+    "frequency": 1438129
+  },
+  {
+    "word": "si",
+    "frequency": 1409401
+  },
+  {
+    "word": "du",
+    "frequency": 1337227
+  },
+  {
+    "word": "y",
+    "frequency": 1320695
+  },
+  {
+    "word": "suis",
+    "frequency": 1303070
+  },
+  {
+    "word": "non",
+    "frequency": 1290498
+  },
+  {
+    "word": "t'",
+    "frequency": 1257857
+  },
+  {
+    "word": "avec",
+    "frequency": 1256800
+  },
+  {
+    "word": "tout",
+    "frequency": 1243107
+  },
+  {
+    "word": "plus",
+    "frequency": 1214520
+  },
+  {
+    "word": "mon",
+    "frequency": 1195613
+  },
+  {
+    "word": "m'",
+    "frequency": 1141238
+  },
+  {
+    "word": "te",
+    "frequency": 1127735
+  },
+  {
+    "word": "au",
+    "frequency": 1109359
+  },
+  {
+    "word": "fait",
+    "frequency": 1054966
+  },
+  {
+    "word": "moi",
+    "frequency": 1048758
+  },
+  {
+    "word": "s'",
+    "frequency": 1037629
+  },
+  {
+    "word": "oui",
+    "frequency": 1001703
+  },
+  {
+    "word": "va",
+    "frequency": 989526
+  },
+  {
+    "word": "était",
+    "frequency": 985841
+  },
+  {
+    "word": "as",
+    "frequency": 974673
+  },
+  {
+    "word": "faire",
+    "frequency": 966573
+  },
+  {
+    "word": "ils",
+    "frequency": 945659
+  },
+  {
+    "word": "sur",
+    "frequency": 939169
+  },
+  {
+    "word": "quoi",
+    "frequency": 894291
+  },
+  {
+    "word": "se",
+    "frequency": 867737
+  },
+  {
+    "word": "comme",
+    "frequency": 864987
+  },
+  {
+    "word": "sais",
+    "frequency": 851748
+  },
+  {
+    "word": "être",
+    "frequency": 743252
+  },
+  {
+    "word": "veux",
+    "frequency": 738917
+  },
+  {
+    "word": "ici",
+    "frequency": 725494
+  },
+  {
+    "word": "ma",
+    "frequency": 716527
+  },
+  {
+    "word": "toi",
+    "frequency": 707904
+  },
+  {
+    "word": "est-ce",
+    "frequency": 707256
+  },
+  {
+    "word": "dit",
+    "frequency": 701414
+  },
+  {
+    "word": "lui",
+    "frequency": 689708
+  },
+  {
+    "word": "votre",
+    "frequency": 677006
+  },
+  {
+    "word": "es",
+    "frequency": 662531
+  },
+  {
+    "word": "pourquoi",
+    "frequency": 657070
+  },
+  {
+    "word": "où",
+    "frequency": 643564
+  },
+  {
+    "word": "là",
+    "frequency": 643024
+  },
+  {
+    "word": "rien",
+    "frequency": 638070
+  },
+  {
+    "word": "cette",
+    "frequency": 626319
+  },
+  {
+    "word": "sont",
+    "frequency": 609102
+  },
+  {
+    "word": "quand",
+    "frequency": 598113
+  },
+  {
+    "word": "peux",
+    "frequency": 594578
+  },
+  {
+    "word": "dire",
+    "frequency": 586553
+  },
+  {
+    "word": "son",
+    "frequency": 585229
+  },
+  {
+    "word": "avez",
+    "frequency": 552796
+  },
+  {
+    "word": "vais",
+    "frequency": 542593
+  },
+  {
+    "word": "alors",
+    "frequency": 542173
+  },
+  {
+    "word": "ton",
+    "frequency": 540446
+  },
+  {
+    "word": "comment",
+    "frequency": 528569
+  },
+  {
+    "word": "par",
+    "frequency": 519463
+  },
+  {
+    "word": "ou",
+    "frequency": 497358
+  },
+  {
+    "word": "chose",
+    "frequency": 490339
+  },
+  {
+    "word": "bon",
+    "frequency": 483364
+  },
+  {
+    "word": "ont",
+    "frequency": 471659
+  },
+  {
+    "word": "merci",
+    "frequency": 471415
+  },
+  {
+    "word": "juste",
+    "frequency": 465932
+  },
+  {
+    "word": "très",
+    "frequency": 462324
+  },
+  {
+    "word": "jamais",
+    "frequency": 436873
+  },
+  {
+    "word": "été",
+    "frequency": 432574
+  },
+  {
+    "word": "aussi",
+    "frequency": 427827
+  },
+  {
+    "word": "avoir",
+    "frequency": 427178
+  },
+  {
+    "word": "vraiment",
+    "frequency": 423339
+  },
+  {
+    "word": "voir",
+    "frequency": 419803
+  },
+  {
+    "word": "même",
+    "frequency": 411247
+  },
+  {
+    "word": "sa",
+    "frequency": 408233
+  },
+  {
+    "word": "oh",
+    "frequency": 408070
+  },
+  {
+    "word": "maintenant",
+    "frequency": 402585
+  },
+  {
+    "word": "tous",
+    "frequency": 399645
+  },
+  {
+    "word": "peut",
+    "frequency": 393199
+  },
+  {
+    "word": "deux",
+    "frequency": 388269
+  },
+  {
+    "word": "ces",
+    "frequency": 388071
+  },
+  {
+    "word": "êtes",
+    "frequency": 376665
+  },
+  {
+    "word": "allez",
+    "frequency": 374660
+  },
+  {
+    "word": "ta",
+    "frequency": 373455
+  },
+  {
+    "word": "autre",
+    "frequency": 370961
+  },
+  {
+    "word": "peu",
+    "frequency": 354756
+  },
+  {
+    "word": "temps",
+    "frequency": 354330
+  },
+  {
+    "word": "quelque",
+    "frequency": 353553
+  },
+  {
+    "word": "fais",
+    "frequency": 353373
+  },
+  {
+    "word": "toujours",
+    "frequency": 345760
+  },
+  {
+    "word": "encore",
+    "frequency": 342386
+  },
+  {
+    "word": "notre",
+    "frequency": 339810
+  },
+  {
+    "word": "mes",
+    "frequency": 332672
+  },
+  {
+    "word": "besoin",
+    "frequency": 329446
+  },
+  {
+    "word": "avait",
+    "frequency": 320073
+  },
+  {
+    "word": "accord",
+    "frequency": 315183
+  },
+  {
+    "word": "faut",
+    "frequency": 313023
+  },
+  {
+    "word": "dois",
+    "frequency": 310780
+  },
+  {
+    "word": "vie",
+    "frequency": 310140
+  },
+  {
+    "word": "peut-être",
+    "frequency": 306785
+  },
+  {
+    "word": "aller",
+    "frequency": 303502
+  },
+  {
+    "word": "fois",
+    "frequency": 297685
+  },
+  {
+    "word": "vu",
+    "frequency": 290541
+  },
+  {
+    "word": "donc",
+    "frequency": 281973
+  },
+  {
+    "word": "sans",
+    "frequency": 281163
+  },
+  {
+    "word": "monde",
+    "frequency": 277005
+  },
+  {
+    "word": "étais",
+    "frequency": 276408
+  },
+  {
+    "word": "parce",
+    "frequency": 273723
+  },
+  {
+    "word": "avant",
+    "frequency": 272706
+  },
+  {
+    "word": "sûr",
+    "frequency": 271047
+  },
+  {
+    "word": "trop",
+    "frequency": 265575
+  },
+  {
+    "word": "quelqu'",
+    "frequency": 265286
+  },
+  {
+    "word": "parler",
+    "frequency": 262709
+  },
+  {
+    "word": "personne",
+    "frequency": 260005
+  },
+  {
+    "word": "avais",
+    "frequency": 257602
+  },
+  {
+    "word": "père",
+    "frequency": 257456
+  },
+  {
+    "word": "crois",
+    "frequency": 251561
+  },
+  {
+    "word": "après",
+    "frequency": 250383
+  },
+  {
+    "word": "aux",
+    "frequency": 244896
+  },
+  {
+    "word": "dieu",
+    "frequency": 242078
+  },
+  {
+    "word": "ouais",
+    "frequency": 241407
+  },
+  {
+    "word": "ses",
+    "frequency": 240780
+  },
+  {
+    "word": "pense",
+    "frequency": 240390
+  },
+  {
+    "word": "eu",
+    "frequency": 238206
+  },
+  {
+    "word": "aime",
+    "frequency": 237696
+  },
+  {
+    "word": "leur",
+    "frequency": 236536
+  },
+  {
+    "word": "homme",
+    "frequency": 236357
+  },
+  {
+    "word": "viens",
+    "frequency": 233234
+  },
+  {
+    "word": "vrai",
+    "frequency": 233001
+  },
+  {
+    "word": "femme",
+    "frequency": 232974
+  },
+  {
+    "word": "ok",
+    "frequency": 228115
+  },
+  {
+    "word": "doit",
+    "frequency": 227951
+  },
+  {
+    "word": "veut",
+    "frequency": 227166
+  },
+  {
+    "word": "ans",
+    "frequency": 225795
+  },
+  {
+    "word": "m.",
+    "frequency": 223793
+  },
+  {
+    "word": "mal",
+    "frequency": 219886
+  },
+  {
+    "word": "chez",
+    "frequency": 218436
+  },
+  {
+    "word": "déjà",
+    "frequency": 214718
+  },
+  {
+    "word": "depuis",
+    "frequency": 214022
+  },
+  {
+    "word": "beaucoup",
+    "frequency": 211787
+  },
+  {
+    "word": "vos",
+    "frequency": 211081
+  },
+  {
+    "word": "bonne",
+    "frequency": 209592
+  },
+  {
+    "word": "mort",
+    "frequency": 208796
+  },
+  {
+    "word": "mieux",
+    "frequency": 205274
+  },
+  {
+    "word": "vas",
+    "frequency": 203968
+  },
+  {
+    "word": "mère",
+    "frequency": 202937
+  },
+  {
+    "word": "sera",
+    "frequency": 202795
+  },
+  {
+    "word": "dis",
+    "frequency": 201949
+  },
+  {
+    "word": "fille",
+    "frequency": 201540
+  },
+  {
+    "word": "tes",
+    "frequency": 199689
+  },
+  {
+    "word": "gens",
+    "frequency": 198558
+  },
+  {
+    "word": "quel",
+    "frequency": 193928
+  },
+  {
+    "word": "vois",
+    "frequency": 193613
+  },
+  {
+    "word": "désolé",
+    "frequency": 191841
+  },
+  {
+    "word": "ca",
+    "frequency": 189898
+  },
+  {
+    "word": "voilà",
+    "frequency": 189677
+  },
+  {
+    "word": "avons",
+    "frequency": 186788
+  },
+  {
+    "word": "petit",
+    "frequency": 186600
+  },
+  {
+    "word": "maison",
+    "frequency": 185035
+  },
+  {
+    "word": "soit",
+    "frequency": 179962
+  },
+  {
+    "word": "cela",
+    "frequency": 177397
+  },
+  {
+    "word": "autres",
+    "frequency": 175480
+  },
+  {
+    "word": "toute",
+    "frequency": 174066
+  },
+  {
+    "word": "soir",
+    "frequency": 172574
+  },
+  {
+    "word": "passé",
+    "frequency": 172214
+  },
+  {
+    "word": "prendre",
+    "frequency": 170367
+  },
+  {
+    "word": "jour",
+    "frequency": 170304
+  },
+  {
+    "word": "monsieur",
+    "frequency": 164959
+  },
+  {
+    "word": "nos",
+    "frequency": 164465
+  },
+  {
+    "word": "savoir",
+    "frequency": 163428
+  },
+  {
+    "word": "choses",
+    "frequency": 163193
+  },
+  {
+    "word": "salut",
+    "frequency": 160990
+  },
+  {
+    "word": "cet",
+    "frequency": 160783
+  },
+  {
+    "word": "nom",
+    "frequency": 160549
+  },
+  {
+    "word": "argent",
+    "frequency": 159413
+  },
+  {
+    "word": "bonjour",
+    "frequency": 156301
+  },
+  {
+    "word": "nuit",
+    "frequency": 155789
+  },
+  {
+    "word": "raison",
+    "frequency": 153137
+  },
+  {
+    "word": "moins",
+    "frequency": 153102
+  },
+  {
+    "word": "arrive",
+    "frequency": 152291
+  },
+  {
+    "word": "maman",
+    "frequency": 151089
+  },
+  {
+    "word": "reste",
+    "frequency": 150311
+  },
+  {
+    "word": "moment",
+    "frequency": 149622
+  },
+  {
+    "word": "voulais",
+    "frequency": 149394
+  },
+  {
+    "word": "seul",
+    "frequency": 149265
+  },
+  {
+    "word": "aider",
+    "frequency": 148607
+  },
+  {
+    "word": "air",
+    "frequency": 148370
+  },
+  {
+    "word": "entre",
+    "frequency": 147420
+  },
+  {
+    "word": "papa",
+    "frequency": 146818
+  },
+  {
+    "word": "passe",
+    "frequency": 144680
+  },
+  {
+    "word": "aurais",
+    "frequency": 143292
+  },
+  {
+    "word": "problème",
+    "frequency": 141208
+  },
+  {
+    "word": "ah",
+    "frequency": 140158
+  },
+  {
+    "word": "peur",
+    "frequency": 139829
+  },
+  {
+    "word": "regarde",
+    "frequency": 138016
+  },
+  {
+    "word": "voulez",
+    "frequency": 137416
+  },
+  {
+    "word": "gars",
+    "frequency": 136154
+  },
+  {
+    "word": "trouvé",
+    "frequency": 135198
+  },
+  {
+    "word": "fils",
+    "frequency": 134600
+  },
+  {
+    "word": "attends",
+    "frequency": 134144
+  },
+  {
+    "word": "savez",
+    "frequency": 133759
+  },
+  {
+    "word": "jusqu'",
+    "frequency": 133102
+  },
+  {
+    "word": "trouver",
+    "frequency": 132646
+  },
+  {
+    "word": "trois",
+    "frequency": 132625
+  },
+  {
+    "word": "assez",
+    "frequency": 132619
+  },
+  {
+    "word": "famille",
+    "frequency": 132352
+  },
+  {
+    "word": "dû",
+    "frequency": 132063
+  },
+  {
+    "word": "eh",
+    "frequency": 131788
+  },
+  {
+    "word": "toutes",
+    "frequency": 131387
+  },
+  {
+    "word": "plaît",
+    "frequency": 131162
+  },
+  {
+    "word": "pourrait",
+    "frequency": 130894
+  },
+  {
+    "word": "travail",
+    "frequency": 130261
+  },
+  {
+    "word": "pris",
+    "frequency": 129066
+  },
+  {
+    "word": "pu",
+    "frequency": 128934
+  },
+  {
+    "word": "tête",
+    "frequency": 128754
+  },
+  {
+    "word": "quelle",
+    "frequency": 128659
+  },
+  {
+    "word": "sait",
+    "frequency": 128125
+  },
+  {
+    "word": "sommes",
+    "frequency": 127717
+  },
+  {
+    "word": "appelle",
+    "frequency": 127367
+  },
+  {
+    "word": "quelques",
+    "frequency": 127034
+  },
+  {
+    "word": "faites",
+    "frequency": 125636
+  },
+  {
+    "word": "partir",
+    "frequency": 125282
+  },
+  {
+    "word": "vite",
+    "frequency": 125063
+  },
+  {
+    "word": "arrête",
+    "frequency": 124854
+  },
+  {
+    "word": "seule",
+    "frequency": 124521
+  },
+  {
+    "word": "serait",
+    "frequency": 123944
+  },
+  {
+    "word": "voiture",
+    "frequency": 123524
+  },
+  {
+    "word": "enfants",
+    "frequency": 123384
+  },
+  {
+    "word": "tuer",
+    "frequency": 121829
+  },
+  {
+    "word": "merde",
+    "frequency": 121318
+  },
+  {
+    "word": "hé",
+    "frequency": 121065
+  },
+  {
+    "word": "pendant",
+    "frequency": 121060
+  },
+  {
+    "word": "idée",
+    "frequency": 120671
+  },
+  {
+    "word": "chance",
+    "frequency": 120655
+  },
+  {
+    "word": "parle",
+    "frequency": 120341
+  },
+  {
+    "word": "aurait",
+    "frequency": 120181
+  },
+  {
+    "word": "part",
+    "frequency": 119964
+  },
+  {
+    "word": "elles",
+    "frequency": 118978
+  },
+  {
+    "word": "jours",
+    "frequency": 118455
+  },
+  {
+    "word": "grand",
+    "frequency": 117213
+  },
+  {
+    "word": "aujourd'hui",
+    "frequency": 117159
+  },
+  {
+    "word": "venir",
+    "frequency": 116762
+  },
+  {
+    "word": "ami",
+    "frequency": 116639
+  },
+  {
+    "word": "demain",
+    "frequency": 116541
+  },
+  {
+    "word": "hein",
+    "frequency": 116301
+  },
+  {
+    "word": "tard",
+    "frequency": 115148
+  },
+  {
+    "word": "puis",
+    "frequency": 115038
+  },
+  {
+    "word": "truc",
+    "frequency": 114959
+  },
+  {
+    "word": "passer",
+    "frequency": 114718
+  },
+  {
+    "word": "petite",
+    "frequency": 114295
+  },
+  {
+    "word": "tant",
+    "frequency": 113917
+  },
+  {
+    "word": "connais",
+    "frequency": 113815
+  },
+  {
+    "word": "combien",
+    "frequency": 113220
+  },
+  {
+    "word": "mec",
+    "frequency": 113219
+  },
+  {
+    "word": "sens",
+    "frequency": 112925
+  },
+  {
+    "word": "pouvez",
+    "frequency": 112615
+  },
+  {
+    "word": "porte",
+    "frequency": 110258
+  },
+  {
+    "word": "sortir",
+    "frequency": 109313
+  },
+  {
+    "word": "super",
+    "frequency": 108980
+  },
+  {
+    "word": "heure",
+    "frequency": 108452
+  },
+  {
+    "word": "contre",
+    "frequency": 108451
+  },
+  {
+    "word": "coup",
+    "frequency": 108065
+  },
+  {
+    "word": "comprends",
+    "frequency": 107885
+  },
+  {
+    "word": "entendu",
+    "frequency": 107777
+  },
+  {
+    "word": "vient",
+    "frequency": 107616
+  },
+  {
+    "word": "allons",
+    "frequency": 106551
+  },
+  {
+    "word": "ensemble",
+    "frequency": 106057
+  },
+  {
+    "word": "nouveau",
+    "frequency": 105566
+  },
+  {
+    "word": "amour",
+    "frequency": 104503
+  },
+  {
+    "word": "importe",
+    "frequency": 104429
+  },
+  {
+    "word": "sang",
+    "frequency": 103824
+  },
+  {
+    "word": "désolée",
+    "frequency": 102105
+  },
+  {
+    "word": "cas",
+    "frequency": 100615
+  },
+  {
+    "word": "sous",
+    "frequency": 100518
+  },
+  {
+    "word": "rester",
+    "frequency": 99983
+  },
+  {
+    "word": "amis",
+    "frequency": 99948
+  },
+  {
+    "word": "prends",
+    "frequency": 99491
+  },
+  {
+    "word": "fini",
+    "frequency": 98823
+  },
+  {
+    "word": "hommes",
+    "frequency": 98230
+  },
+  {
+    "word": "tué",
+    "frequency": 98218
+  },
+  {
+    "word": "question",
+    "frequency": 97869
+  },
+  {
+    "word": "partie",
+    "frequency": 97788
+  },
+  {
+    "word": "histoire",
+    "frequency": 97363
+  },
+  {
+    "word": "devrais",
+    "frequency": 97220
+  },
+  {
+    "word": "aide",
+    "frequency": 96574
+  },
+  {
+    "word": "dernière",
+    "frequency": 96425
+  },
+  {
+    "word": "demande",
+    "frequency": 95954
+  },
+  {
+    "word": "chercher",
+    "frequency": 95887
+  },
+  {
+    "word": "pensais",
+    "frequency": 95747
+  },
+  {
+    "word": "genre",
+    "frequency": 95698
+  },
+  {
+    "word": "seulement",
+    "frequency": 95569
+  },
+  {
+    "word": "police",
+    "frequency": 95229
+  },
+  {
+    "word": "car",
+    "frequency": 94921
+  },
+  {
+    "word": "mois",
+    "frequency": 94016
+  },
+  {
+    "word": "frère",
+    "frequency": 94005
+  },
+  {
+    "word": "laisser",
+    "frequency": 93545
+  },
+  {
+    "word": "aucun",
+    "frequency": 93134
+  },
+  {
+    "word": "mettre",
+    "frequency": 92980
+  },
+  {
+    "word": "eux",
+    "frequency": 92010
+  },
+  {
+    "word": "laisse",
+    "frequency": 91272
+  },
+  {
+    "word": "chaque",
+    "frequency": 91035
+  },
+  {
+    "word": "ville",
+    "frequency": 90067
+  },
+  {
+    "word": "arrivé",
+    "frequency": 89653
+  },
+  {
+    "word": "devrait",
+    "frequency": 89639
+  },
+  {
+    "word": "parlé",
+    "frequency": 89232
+  },
+  {
+    "word": "avez-vous",
+    "frequency": 88861
+  },
+  {
+    "word": "vont",
+    "frequency": 88659
+  },
+  {
+    "word": "longtemps",
+    "frequency": 88619
+  },
+  {
+    "word": "aucune",
+    "frequency": 87577
+  },
+  {
+    "word": "heures",
+    "frequency": 87343
+  },
+  {
+    "word": "bébé",
+    "frequency": 86634
+  },
+  {
+    "word": "place",
+    "frequency": 86562
+  },
+  {
+    "word": "revoir",
+    "frequency": 86062
+  },
+  {
+    "word": "putain",
+    "frequency": 85798
+  },
+  {
+    "word": "compris",
+    "frequency": 85603
+  },
+  {
+    "word": "ni",
+    "frequency": 84992
+  },
+  {
+    "word": "savais",
+    "frequency": 84626
+  },
+  {
+    "word": "leurs",
+    "frequency": 84050
+  },
+  {
+    "word": "étaient",
+    "frequency": 83848
+  },
+  {
+    "word": "attention",
+    "frequency": 83667
+  },
+  {
+    "word": "donner",
+    "frequency": 83428
+  },
+  {
+    "word": "affaire",
+    "frequency": 83076
+  },
+  {
+    "word": "endroit",
+    "frequency": 82941
+  },
+  {
+    "word": "pourrais",
+    "frequency": 82579
+  },
+  {
+    "word": "corps",
+    "frequency": 82565
+  },
+  {
+    "word": "façon",
+    "frequency": 82429
+  },
+  {
+    "word": "donné",
+    "frequency": 82427
+  },
+  {
+    "word": "est-il",
+    "frequency": 82359
+  },
+  {
+    "word": "voici",
+    "frequency": 82156
+  },
+  {
+    "word": "train",
+    "frequency": 82087
+  },
+  {
+    "word": "dont",
+    "frequency": 81842
+  },
+  {
+    "word": "écoute",
+    "frequency": 81813
+  },
+  {
+    "word": "yeux",
+    "frequency": 81633
+  },
+  {
+    "word": "trouve",
+    "frequency": 81473
+  },
+  {
+    "word": "pouvoir",
+    "frequency": 81369
+  },
+  {
+    "word": "type",
+    "frequency": 81069
+  },
+  {
+    "word": "perdu",
+    "frequency": 80940
+  },
+  {
+    "word": "premier",
+    "frequency": 80900
+  },
+  {
+    "word": "première",
+    "frequency": 80647
+  },
+  {
+    "word": "côté",
+    "frequency": 80162
+  },
+  {
+    "word": "point",
+    "frequency": 80138
+  },
+  {
+    "word": "tellement",
+    "frequency": 80089
+  },
+  {
+    "word": "main",
+    "frequency": 79961
+  },
+  {
+    "word": "tiens",
+    "frequency": 79293
+  },
+  {
+    "word": "sois",
+    "frequency": 79031
+  },
+  {
+    "word": "enfant",
+    "frequency": 78904
+  },
+  {
+    "word": "vieux",
+    "frequency": 78652
+  },
+  {
+    "word": "matin",
+    "frequency": 78600
+  },
+  {
+    "word": "venu",
+    "frequency": 77238
+  },
+  {
+    "word": "pardon",
+    "frequency": 77144
+  },
+  {
+    "word": "là-bas",
+    "frequency": 76653
+  },
+  {
+    "word": "suite",
+    "frequency": 76545
+  },
+  {
+    "word": "vers",
+    "frequency": 76542
+  },
+  {
+    "word": "minutes",
+    "frequency": 76229
+  },
+  {
+    "word": "demandé",
+    "frequency": 76129
+  },
+  {
+    "word": "venez",
+    "frequency": 76029
+  },
+  {
+    "word": "devant",
+    "frequency": 75940
+  },
+  {
+    "word": "dr",
+    "frequency": 75475
+  },
+  {
+    "word": "enfin",
+    "frequency": 75391
+  },
+  {
+    "word": "arrêter",
+    "frequency": 74860
+  },
+  {
+    "word": "cause",
+    "frequency": 74747
+  },
+  {
+    "word": "nouvelle",
+    "frequency": 74677
+  },
+  {
+    "word": "attendez",
+    "frequency": 74608
+  },
+  {
+    "word": "chambre",
+    "frequency": 74591
+  },
+  {
+    "word": "droit",
+    "frequency": 74535
+  },
+  {
+    "word": "parti",
+    "frequency": 74523
+  },
+  {
+    "word": "mis",
+    "frequency": 74511
+  },
+  {
+    "word": "eau",
+    "frequency": 74267
+  },
+  {
+    "word": "compte",
+    "frequency": 74243
+  },
+  {
+    "word": "dirait",
+    "frequency": 74046
+  },
+  {
+    "word": "terre",
+    "frequency": 74029
+  },
+  {
+    "word": "belle",
+    "frequency": 74001
+  },
+  {
+    "word": "espère",
+    "frequency": 73948
+  },
+  {
+    "word": "aimerais",
+    "frequency": 73931
+  },
+  {
+    "word": "loin",
+    "frequency": 73779
+  },
+  {
+    "word": "as-tu",
+    "frequency": 73213
+  },
+  {
+    "word": "mari",
+    "frequency": 72921
+  },
+  {
+    "word": "donne",
+    "frequency": 72911
+  },
+  {
+    "word": "fin",
+    "frequency": 72794
+  },
+  {
+    "word": "croire",
+    "frequency": 72465
+  },
+  {
+    "word": "mme",
+    "frequency": 72376
+  },
+  {
+    "word": "aura",
+    "frequency": 72059
+  },
+  {
+    "word": "gros",
+    "frequency": 71871
+  },
+  {
+    "word": "boulot",
+    "frequency": 71509
+  },
+  {
+    "word": "plutôt",
+    "frequency": 71199
+  },
+  {
+    "word": "chérie",
+    "frequency": 71179
+  },
+  {
+    "word": "prêt",
+    "frequency": 70737
+  },
+  {
+    "word": "filles",
+    "frequency": 70420
+  },
+  {
+    "word": "bureau",
+    "frequency": 70339
+  },
+  {
+    "word": "mourir",
+    "frequency": 70130
+  },
+  {
+    "word": "hier",
+    "frequency": 69937
+  },
+  {
+    "word": "possible",
+    "frequency": 69891
+  },
+  {
+    "word": "jouer",
+    "frequency": 69516
+  },
+  {
+    "word": "demander",
+    "frequency": 69293
+  },
+  {
+    "word": "celui",
+    "frequency": 69179
+  },
+  {
+    "word": "voulait",
+    "frequency": 68950
+  },
+  {
+    "word": "beau",
+    "frequency": 67782
+  },
+  {
+    "word": "jeune",
+    "frequency": 67609
+  },
+  {
+    "word": "euh",
+    "frequency": 67392
+  },
+  {
+    "word": "dehors",
+    "frequency": 67348
+  },
+  {
+    "word": "docteur",
+    "frequency": 67286
+  },
+  {
+    "word": "a-t-il",
+    "frequency": 67118
+  },
+  {
+    "word": "confiance",
+    "frequency": 67045
+  },
+  {
+    "word": "appeler",
+    "frequency": 67001
+  },
+  {
+    "word": "années",
+    "frequency": 66836
+  },
+  {
+    "word": "vérité",
+    "frequency": 66327
+  },
+  {
+    "word": "école",
+    "frequency": 66151
+  },
+  {
+    "word": "chef",
+    "frequency": 66020
+  },
+  {
+    "word": "femmes",
+    "frequency": 66013
+  },
+  {
+    "word": "propos",
+    "frequency": 65929
+  },
+  {
+    "word": "semaine",
+    "frequency": 65429
+  },
+  {
+    "word": "vivre",
+    "frequency": 64664
+  },
+  {
+    "word": "regardez",
+    "frequency": 64586
+  },
+  {
+    "word": "feu",
+    "frequency": 64459
+  },
+  {
+    "word": "journée",
+    "frequency": 63963
+  },
+  {
+    "word": "madame",
+    "frequency": 63463
+  },
+  {
+    "word": "hey",
+    "frequency": 63364
+  },
+  {
+    "word": "téléphone",
+    "frequency": 62803
+  },
+  {
+    "word": "près",
+    "frequency": 62659
+  },
+  {
+    "word": "affaires",
+    "frequency": 62509
+  },
+  {
+    "word": "meilleur",
+    "frequency": 62322
+  },
+  {
+    "word": "devez",
+    "frequency": 62051
+  },
+  {
+    "word": "dessus",
+    "frequency": 62027
+  },
+  {
+    "word": "mains",
+    "frequency": 61954
+  },
+  {
+    "word": "penses",
+    "frequency": 61741
+  },
+  {
+    "word": "prie",
+    "frequency": 61306
+  },
+  {
+    "word": "équipe",
+    "frequency": 61172
+  },
+  {
+    "word": "vas-y",
+    "frequency": 61165
+  },
+  {
+    "word": "grande",
+    "frequency": 61118
+  },
+  {
+    "word": "manger",
+    "frequency": 60951
+  },
+  {
+    "word": "arriver",
+    "frequency": 60824
+  },
+  {
+    "word": "dur",
+    "frequency": 60815
+  },
+  {
+    "word": "guerre",
+    "frequency": 60533
+  },
+  {
+    "word": "ait",
+    "frequency": 60333
+  },
+  {
+    "word": "appelé",
+    "frequency": 60257
+  },
+  {
+    "word": "marche",
+    "frequency": 60060
+  },
+  {
+    "word": "sécurité",
+    "frequency": 59750
+  },
+  {
+    "word": "garçon",
+    "frequency": 59725
+  },
+  {
+    "word": "essaie",
+    "frequency": 59674
+  },
+  {
+    "word": "important",
+    "frequency": 59641
+  },
+  {
+    "word": "dites",
+    "frequency": 59498
+  },
+  {
+    "word": "exactement",
+    "frequency": 59442
+  },
+  {
+    "word": "font",
+    "frequency": 59434
+  },
+  {
+    "word": "fort",
+    "frequency": 59357
+  },
+  {
+    "word": "presque",
+    "frequency": 59183
+  },
+  {
+    "word": "plein",
+    "frequency": 59129
+  },
+  {
+    "word": "derrière",
+    "frequency": 59059
+  },
+  {
+    "word": "ben",
+    "frequency": 59042
+  },
+  {
+    "word": "mariage",
+    "frequency": 58910
+  },
+  {
+    "word": "parents",
+    "frequency": 58708
+  },
+  {
+    "word": "capitaine",
+    "frequency": 58413
+  },
+  {
+    "word": "dernier",
+    "frequency": 58399
+  },
+  {
+    "word": "fou",
+    "frequency": 58314
+  },
+  {
+    "word": "ceux",
+    "frequency": 58210
+  },
+  {
+    "word": "tomber",
+    "frequency": 57627
+  },
+  {
+    "word": "attendre",
+    "frequency": 57610
+  },
+  {
+    "word": "vue",
+    "frequency": 57392
+  },
+  {
+    "word": "pensé",
+    "frequency": 57366
+  },
+  {
+    "word": "souviens",
+    "frequency": 57155
+  },
+  {
+    "word": "envie",
+    "frequency": 56862
+  },
+  {
+    "word": "fête",
+    "frequency": 56661
+  },
+  {
+    "word": "jeu",
+    "frequency": 56566
+  },
+  {
+    "word": "génial",
+    "frequency": 56189
+  },
+  {
+    "word": "pays",
+    "frequency": 55567
+  },
+  {
+    "word": "garde",
+    "frequency": 55293
+  },
+  {
+    "word": "cours",
+    "frequency": 54886
+  },
+  {
+    "word": "bientôt",
+    "frequency": 54494
+  },
+  {
+    "word": "ii",
+    "frequency": 54338
+  },
+  {
+    "word": "numéro",
+    "frequency": 54135
+  },
+  {
+    "word": "personnes",
+    "frequency": 54104
+  },
+  {
+    "word": "cinq",
+    "frequency": 54092
+  },
+  {
+    "word": "parfait",
+    "frequency": 53772
+  },
+  {
+    "word": "excusez-moi",
+    "frequency": 53742
+  },
+  {
+    "word": "laissé",
+    "frequency": 53626
+  },
+  {
+    "word": "ainsi",
+    "frequency": 53523
+  },
+  {
+    "word": "retour",
+    "frequency": 53349
+  },
+  {
+    "word": "semble",
+    "frequency": 53159
+  },
+  {
+    "word": "autant",
+    "frequency": 53097
+  },
+  {
+    "word": "peine",
+    "frequency": 53089
+  },
+  {
+    "word": "minute",
+    "frequency": 53057
+  },
+  {
+    "word": "essayé",
+    "frequency": 52897
+  },
+  {
+    "word": "plan",
+    "frequency": 52873
+  },
+  {
+    "word": "instant",
+    "frequency": 52720
+  },
+  {
+    "word": "serai",
+    "frequency": 52686
+  },
+  {
+    "word": "prison",
+    "frequency": 52666
+  },
+  {
+    "word": "penser",
+    "frequency": 52612
+  },
+  {
+    "word": "essayer",
+    "frequency": 52345
+  },
+  {
+    "word": "prend",
+    "frequency": 52147
+  },
+  {
+    "word": "arme",
+    "frequency": 52139
+  },
+  {
+    "word": "mauvais",
+    "frequency": 52116
+  },
+  {
+    "word": "mot",
+    "frequency": 52103
+  },
+  {
+    "word": "travailler",
+    "frequency": 51814
+  },
+  {
+    "word": "quatre",
+    "frequency": 51716
+  },
+  {
+    "word": "rentrer",
+    "frequency": 51544
+  },
+  {
+    "word": "regarder",
+    "frequency": 51486
+  },
+  {
+    "word": "choix",
+    "frequency": 51014
+  },
+  {
+    "word": "êtes-vous",
+    "frequency": 50919
+  },
+  {
+    "word": "parfois",
+    "frequency": 50714
+  },
+  {
+    "word": "film",
+    "frequency": 50463
+  },
+  {
+    "word": "abord",
+    "frequency": 50320
+  },
+  {
+    "word": "voyez",
+    "frequency": 50199
+  },
+  {
+    "word": "faute",
+    "frequency": 50187
+  },
+  {
+    "word": "facile",
+    "frequency": 50015
+  },
+  {
+    "word": "croyais",
+    "frequency": 49992
+  },
+  {
+    "word": "bas",
+    "frequency": 49872
+  },
+  {
+    "word": "changer",
+    "frequency": 49767
+  },
+  {
+    "word": "entendre",
+    "frequency": 49655
+  },
+  {
+    "word": "plaisir",
+    "frequency": 49365
+  },
+  {
+    "word": "heureux",
+    "frequency": 49316
+  },
+  {
+    "word": "entrer",
+    "frequency": 49076
+  },
+  {
+    "word": "voudrais",
+    "frequency": 49061
+  },
+  {
+    "word": "es-tu",
+    "frequency": 48889
+  },
+  {
+    "word": "propre",
+    "frequency": 48778
+  },
+  {
+    "word": "étiez",
+    "frequency": 48770
+  },
+  {
+    "word": "tour",
+    "frequency": 48730
+  },
+  {
+    "word": "fera",
+    "frequency": 48729
+  },
+  {
+    "word": "ensuite",
+    "frequency": 48619
+  },
+  {
+    "word": "garder",
+    "frequency": 48491
+  },
+  {
+    "word": "agent",
+    "frequency": 48468
+  },
+  {
+    "word": "allait",
+    "frequency": 48398
+  },
+  {
+    "word": "lit",
+    "frequency": 48374
+  },
+  {
+    "word": "travaille",
+    "frequency": 48194
+  },
+  {
+    "word": "adore",
+    "frequency": 47930
+  },
+  {
+    "word": "amie",
+    "frequency": 47899
+  },
+  {
+    "word": "rendre",
+    "frequency": 47887
+  },
+  {
+    "word": "allons-y",
+    "frequency": 47877
+  },
+  {
+    "word": "route",
+    "frequency": 47877
+  },
+  {
+    "word": "lieu",
+    "frequency": 47846
+  },
+  {
+    "word": "année",
+    "frequency": 47747
+  },
+  {
+    "word": "voit",
+    "frequency": 47662
+  },
+  {
+    "word": "commence",
+    "frequency": 47401
+  },
+  {
+    "word": "service",
+    "frequency": 47219
+  },
+  {
+    "word": "devoir",
+    "frequency": 47066
+  },
+  {
+    "word": "attend",
+    "frequency": 46971
+  },
+  {
+    "word": "drôle",
+    "frequency": 46916
+  },
+  {
+    "word": "difficile",
+    "frequency": 46667
+  },
+  {
+    "word": "sûre",
+    "frequency": 46585
+  },
+  {
+    "word": "pire",
+    "frequency": 46569
+  },
+  {
+    "word": "pos",
+    "frequency": 46544
+  },
+  {
+    "word": "peuvent",
+    "frequency": 46475
+  },
+  {
+    "word": "sujet",
+    "frequency": 46448
+  },
+  {
+    "word": "état",
+    "frequency": 46353
+  },
+  {
+    "word": "ceci",
+    "frequency": 46192
+  },
+  {
+    "word": "impossible",
+    "frequency": 46058
+  },
+  {
+    "word": "sorte",
+    "frequency": 45976
+  },
+  {
+    "word": "perdre",
+    "frequency": 45792
+  },
+  {
+    "word": "dollars",
+    "frequency": 45519
+  },
+  {
+    "word": "voulu",
+    "frequency": 45504
+  },
+  {
+    "word": "morte",
+    "frequency": 45457
+  },
+  {
+    "word": "ira",
+    "frequency": 45398
+  },
+  {
+    "word": "faisait",
+    "frequency": 45293
+  },
+  {
+    "word": "bizarre",
+    "frequency": 45211
+  },
+  {
+    "word": "oublié",
+    "frequency": 44936
+  },
+  {
+    "word": "arrêtez",
+    "frequency": 44843
+  },
+  {
+    "word": "ferai",
+    "frequency": 44832
+  },
+  {
+    "word": "serais",
+    "frequency": 44830
+  },
+  {
+    "word": "tôt",
+    "frequency": 44694
+  },
+  {
+    "word": "inquiète",
+    "frequency": 44638
+  },
+  {
+    "word": "payer",
+    "frequency": 44636
+  },
+  {
+    "word": "coeur",
+    "frequency": 44598
+  },
+  {
+    "word": "dès",
+    "frequency": 44598
+  },
+  {
+    "word": "pouvais",
+    "frequency": 44535
+  },
+  {
+    "word": "reviens",
+    "frequency": 44478
+  },
+  {
+    "word": "chien",
+    "frequency": 44449
+  },
+  {
+    "word": "suffit",
+    "frequency": 44353
+  },
+  {
+    "word": "prenez",
+    "frequency": 44352
+  },
+  {
+    "word": "pensez",
+    "frequency": 44223
+  },
+  {
+    "word": "café",
+    "frequency": 44063
+  },
+  {
+    "word": "calme",
+    "frequency": 44023
+  },
+  {
+    "word": "cherche",
+    "frequency": 43990
+  }
+] as const;

--- a/src/lib/prefix-suggester.ts
+++ b/src/lib/prefix-suggester.ts
@@ -1,0 +1,111 @@
+import { COMMON_FRENCH_WORDS } from "@/data/dictionaries/fr-common-words";
+import { STARTER_WORDS } from "@/data/dictionaries/fr-dictionary";
+
+const MAX_SUGGESTIONS_PER_PREFIX = 8;
+
+const CURATED_WORDS = [
+  "c'est",
+  "c'était",
+  "coucou",
+  "d'accord",
+  "j'adore",
+  "j'arrive",
+  "j'attends",
+  "j'espère",
+  "j'ai",
+  "j'aime",
+  "j'aimerais",
+  "j'étais",
+  "j'avais",
+  "j'aurai",
+  "t'es",
+  "t'as",
+  "t'étais",
+  "t'inquiète",
+  "ok",
+  "parfait",
+  "super",
+  "top",
+  "bravo",
+  "génial",
+  "merci",
+  "salut",
+  "bonjour",
+  "à bientôt",
+  "à tout à l'heure",
+  "à demain",
+  "à plus",
+];
+
+function normalizeForIndex(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z]+/g, "");
+}
+
+const curatedWordEntries = CURATED_WORDS.map((word, index) => ({
+  word,
+  frequency: 10000000 - index * 5000,
+}));
+
+const starterWordEntries = STARTER_WORDS.filter(word => !word.includes(" "))
+  .map((word, index) => ({
+    word,
+    frequency: 500000 - index * 1000,
+  }));
+
+const sortedEntries = [
+  ...curatedWordEntries,
+  ...COMMON_FRENCH_WORDS,
+  ...starterWordEntries,
+]
+  .map(entry => ({
+    word: entry.word,
+    normalized: normalizeForIndex(entry.word),
+    frequency: entry.frequency,
+  }))
+  .filter(entry => entry.normalized.length > 0)
+  .sort((a, b) => b.frequency - a.frequency);
+
+const prefixMap = new Map<string, string[]>();
+
+for (const entry of sortedEntries) {
+  const suggestion = entry.word;
+  const normalized = entry.normalized;
+  for (let i = 1; i <= normalized.length; i += 1) {
+    const prefix = normalized.slice(0, i);
+    const existing = prefixMap.get(prefix);
+    if (!existing) {
+      prefixMap.set(prefix, [suggestion]);
+      continue;
+    }
+    if (existing.includes(suggestion)) continue;
+    if (existing.length >= MAX_SUGGESTIONS_PER_PREFIX) continue;
+    existing.push(suggestion);
+  }
+}
+
+/**
+ * Returns the most frequent French words starting with the provided prefix.
+ */
+export function getPrefixSuggestions(
+  prefix: string,
+  limit = MAX_SUGGESTIONS_PER_PREFIX,
+): string[] {
+  const normalized = normalizeForIndex(prefix);
+  if (!normalized) return [];
+  const matches = prefixMap.get(normalized);
+  if (!matches) return [];
+  return matches.slice(0, limit);
+}
+
+/**
+ * A light-weight check to determine whether a prefix has any candidates.
+ */
+export function hasPrefixSuggestions(prefix: string): boolean {
+  const normalized = normalizeForIndex(prefix);
+  if (!normalized) return false;
+  return prefixMap.has(normalized);
+}


### PR DESCRIPTION
## Summary
- add a frequency-ranked French lexicon to drive on-device suggestions
- build a prefix suggester that prioritizes curated and common words
- integrate the new suggester into the chat hook with caching and remote fallback

## Testing
- npm run lint *(fails: Next.js interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68dae5e11b78832593854ae1fdc36350