### PR TITLE
Improve chat suggestion handling

### DIFF
--- a/src/components/chat/chat-window.tsx
+++ b/src/components/chat/chat-window.tsx
@@ -132,17 +132,24 @@ export function ChatWindow({ conversationId, currentStudent, allStudents, isCrea
     };
     
     const handleApplySuggestion = (suggestion: string) => {
+        const normalizedSuggestion = suggestion.trim();
+        if (!normalizedSuggestion) return;
+
         setNewMessage((prev) => {
             if (!prev.trim()) {
-                return `${suggestion} `;
+                return `${normalizedSuggestion} `;
             }
 
-            const wordMatch = prev.match(/([A-Za-zÀ-ÖØ-öø-ÿ'-]+)$/);
-            if (wordMatch) {
-                return `${prev.slice(0, prev.length - wordMatch[1].length)}${suggestion} `;
+            const trailingWhitespace = /\s+$/.test(prev);
+            if (!trailingWhitespace) {
+                const wordMatch = prev.match(/([A-Za-zÀ-ÖØ-öø-ÿ'-]+)$/);
+                if (wordMatch) {
+                    return `${prev.slice(0, prev.length - wordMatch[1].length)}${normalizedSuggestion} `;
+                }
             }
 
-            return `${prev}${prev.endsWith(' ') ? '' : ' '}${suggestion} `;
+            const base = trailingWhitespace ? prev : `${prev}${prev.endsWith(' ') ? '' : ' '}`;
+            return `${base}${normalizedSuggestion} `;
         });
         textareaRef.current?.focus();
     }

--- a/src/hooks/use-spell-suggestions.ts
+++ b/src/hooks/use-spell-suggestions.ts
@@ -1,17 +1,16 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { STARTER_WORDS } from "@/data/dictionaries/fr-dictionary";
+import { CONTEXTUAL_CONTINUATIONS } from "@/data/dictionaries/fr-contextual-continuations";
 import { getPrefixSuggestions } from "@/lib/prefix-suggester";
 
 const WORD_PATTERN = /([A-Za-zÀ-ÖØ-öø-ÿ'-]+)/g;
-const WORD_CHARACTER_PATTERN = /[A-Za-zÀ-ÖØ-öø-ÿ'-]$/;
-
-function getLastWord(value: string): string {
-  const match = value.match(/([A-Za-zÀ-ÖØ-öø-ÿ'-]+)$/);
-  return match?.[1] || "";
-}
 
 function extractWords(value: string): string[] {
-  return value.match(WORD_PATTERN)?.map(word => word.trim()).filter(Boolean) ?? [];
+  return value
+    .toLowerCase()
+    .match(WORD_PATTERN)
+    ?.map(word => word.trim())
+    .filter(Boolean) ?? [];
 }
 
 export interface UseSpellSuggestionsOptions {
@@ -56,56 +55,146 @@ function resolveOptions(
   };
 }
 
+function collectContextualSuggestions(contextWords: string[]): string[] {
+  if (!contextWords.length) return [];
+
+  const matches: string[] = [];
+  for (const continuation of CONTEXTUAL_CONTINUATIONS) {
+    const expected = continuation.context.map(part => part.toLowerCase());
+    if (expected.length > contextWords.length) continue;
+
+    const slice = contextWords.slice(-expected.length);
+    let isMatch = true;
+    for (let i = 0; i < expected.length; i += 1) {
+      if (slice[i] !== expected[i]) {
+        isMatch = false;
+        break;
+      }
+    }
+
+    if (isMatch) {
+      matches.push(...continuation.suggestions);
+    }
+  }
+
+  return matches;
+}
+
+function mergeSuggestionLists(lists: string[][], maxSuggestions: number): string[] {
+  const merged: string[] = [];
+  const seen = new Set<string>();
+
+  for (const list of lists) {
+    for (const suggestion of list) {
+      const trimmed = suggestion.trim();
+      if (!trimmed) continue;
+      const key = trimmed.toLowerCase();
+      if (seen.has(key)) continue;
+
+      seen.add(key);
+      merged.push(trimmed);
+      if (merged.length >= maxSuggestions) {
+        return merged.slice(0, maxSuggestions);
+      }
+    }
+  }
+
+  return merged.slice(0, maxSuggestions);
+}
+
+export function useSpellSuggestions(
+  text: string,
+  langOrOptions?: string | UseSpellSuggestionsOptions,
+  options?: UseSpellSuggestionsOptions,
+): UseSpellSuggestionsResult {
+  const resolvedOptions = useMemo(
+    () => resolveOptions(langOrOptions, options),
+    [langOrOptions, options],
+  );
 
   const [remoteSuggestions, setRemoteSuggestions] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const debounceWord = useRef<number>();
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
   const cacheRef = useRef<Map<string, string[]>>(new Map());
   const controllerRef = useRef<AbortController | null>(null);
 
   const trimmedText = text.trim();
-  const lastWord = useMemo(() => getLastWord(text), [text]);
+  const hasTrailingWhitespace = /\s$/.test(text);
 
+  const words = useMemo(() => extractWords(text), [text]);
+
+  const activeWord = useMemo(() => {
+    if (hasTrailingWhitespace) return "";
+    return words[words.length - 1] ?? "";
+  }, [words, hasTrailingWhitespace]);
+
+  const contextWords = useMemo(() => {
+    if (!words.length) return [];
+    const base = hasTrailingWhitespace ? words : words.slice(0, -1);
+    return base.slice(-resolvedOptions.contextWindow);
+  }, [words, hasTrailingWhitespace, resolvedOptions.contextWindow]);
+
+  const contextSuggestions = useMemo(
+    () => collectContextualSuggestions(contextWords),
+    [contextWords],
+  );
+
+  const prefixSuggestions = useMemo(() => {
+    if (!activeWord) return [];
+    return getPrefixSuggestions(activeWord, resolvedOptions.maxVisibleSuggestions);
+  }, [activeWord, resolvedOptions.maxVisibleSuggestions]);
+
+  const starterSuggestions = useMemo(() => {
+    return trimmedText ? [] : STARTER_WORDS;
+  }, [trimmedText]);
 
   useEffect(() => {
-    if (debounceWord.current) window.clearTimeout(debounceWord.current);
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = undefined;
+    }
     if (controllerRef.current) {
       controllerRef.current.abort();
       controllerRef.current = null;
     }
 
-
+    if (!trimmedText || trimmedText.length < resolvedOptions.minRemoteLength) {
       setIsLoading(false);
       setRemoteSuggestions([]);
-      return () => undefined;
+      return;
     }
 
-
+    const cacheKey = `${resolvedOptions.lang}:${trimmedText.toLowerCase()}`;
     const cached = cacheRef.current.get(cacheKey);
     if (cached) {
       setRemoteSuggestions(cached);
       setIsLoading(false);
-      return () => undefined;
+      return;
     }
 
     setIsLoading(true);
-    debounceWord.current = window.setTimeout(async () => {
+    debounceRef.current = setTimeout(async () => {
       try {
         controllerRef.current = new AbortController();
         const response = await fetch("/api/spell", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-
+          body: JSON.stringify({ text: trimmedText, lang: resolvedOptions.lang }),
           signal: controllerRef.current.signal,
         });
-        if (response.ok) {
-          const data = await response.json();
 
-          cacheRef.current.set(cacheKey, suggestions);
-          setRemoteSuggestions(suggestions);
-        } else {
+        if (!response.ok) {
           setRemoteSuggestions([]);
+          return;
         }
+
+        const data = await response.json();
+        const suggestions = Array.isArray(data?.suggestions)
+          ? data.suggestions.filter((entry: unknown): entry is string => typeof entry === "string")
+          : [];
+
+        cacheRef.current.set(cacheKey, suggestions);
+        setRemoteSuggestions(suggestions);
       } catch (error) {
         if ((error as Error).name !== "AbortError") {
           console.error("Error fetching spell suggestions:", error);
@@ -115,37 +204,65 @@ function resolveOptions(
         setIsLoading(false);
         controllerRef.current = null;
       }
-
+    }, resolvedOptions.debounceMs);
 
     return () => {
-      if (debounceWord.current) window.clearTimeout(debounceWord.current);
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = undefined;
+      }
       if (controllerRef.current) {
         controllerRef.current.abort();
         controllerRef.current = null;
       }
     };
+  }, [trimmedText, resolvedOptions]);
 
+  const filteredRemoteSuggestions = useMemo(() => {
+    if (!activeWord) return remoteSuggestions;
+    const normalized = activeWord.toLowerCase();
+    return remoteSuggestions.filter(suggestion => suggestion.toLowerCase().startsWith(normalized));
+  }, [remoteSuggestions, activeWord]);
+
+  const localSuggestions = useMemo(() => {
+    const lists: string[][] = [];
+    if (activeWord) lists.push(prefixSuggestions);
+    if (contextSuggestions.length) lists.push(contextSuggestions);
+    if (!trimmedText) lists.push(starterSuggestions);
+
+    const merged = mergeSuggestionLists(lists, resolvedOptions.maxVisibleSuggestions);
+    if (merged.length === 0 && trimmedText) {
+      return mergeSuggestionLists([starterSuggestions], resolvedOptions.maxVisibleSuggestions);
     }
 
-    const merged: string[] = [];
-    const seen = new Set<string>();
+    return merged;
+  }, [
+    activeWord,
+    contextSuggestions,
+    starterSuggestions,
+    prefixSuggestions,
+    trimmedText,
+    resolvedOptions.maxVisibleSuggestions,
+  ]);
 
-    for (const list of [localSuggestions, remoteSuggestions]) {
-      for (const suggestion of list) {
-        if (!suggestion) continue;
-        const trimmedSuggestion = suggestion.trim();
-        if (!trimmedSuggestion) continue;
-        if (seen.has(trimmedSuggestion)) continue;
-        merged.push(trimmedSuggestion);
-        seen.add(trimmedSuggestion);
+  const wordSuggestions = useMemo(() => {
+    const lists: string[][] = [];
+    if (localSuggestions.length) lists.push(localSuggestions);
+    if (filteredRemoteSuggestions.length) lists.push(filteredRemoteSuggestions);
+    if (!lists.length) lists.push(starterSuggestions);
 
-          return merged;
-        }
-      }
-    }
+    return mergeSuggestionLists(lists, resolvedOptions.maxVisibleSuggestions);
+  }, [
+    localSuggestions,
+    filteredRemoteSuggestions,
+    starterSuggestions,
+    resolvedOptions.maxVisibleSuggestions,
+  ]);
 
-    if (merged.length === 0) {
-
-
-  return { wordSuggestions, localSuggestions, contextWords, isLoading };
+  return {
+    wordSuggestions,
+    localSuggestions,
+    contextWords,
+    isLoading,
+  };
 }

--- a/src/lib/prefix-suggester.ts
+++ b/src/lib/prefix-suggester.ts
@@ -1,4 +1,4 @@
-
+import { STARTER_WORDS } from "@/data/dictionaries/fr-dictionary";
 
 const CURATED_WORDS = [
   "c'est",
@@ -32,7 +32,11 @@ const CURATED_WORDS = [
   "à tout à l'heure",
   "à demain",
   "à plus",
+];
 
+const MAX_SUGGESTIONS_PER_PREFIX = 12;
+
+function normalize(value: string): string {
   return value
     .toLowerCase()
     .normalize("NFD")
@@ -40,31 +44,63 @@ const CURATED_WORDS = [
     .replace(/[^a-z]+/g, "");
 }
 
+function buildPrefixMap(words: string[]): Map<string, string[]> {
+  const prefixMap = new Map<string, string[]>();
+  const seenWords = new Set<string>();
 
-  for (let i = 1; i <= normalized.length; i += 1) {
-    const prefix = normalized.slice(0, i);
-    const existing = prefixMap.get(prefix);
-    if (!existing) {
-      prefixMap.set(prefix, [suggestion]);
-      continue;
+  for (const rawWord of words) {
+    const word = rawWord.trim();
+    if (!word) continue;
+
+    const normalized = normalize(word);
+    if (!normalized) continue;
+
+    const dedupeKey = normalized;
+    if (seenWords.has(dedupeKey)) continue;
+    seenWords.add(dedupeKey);
+
+    for (let i = 1; i <= normalized.length; i += 1) {
+      const prefix = normalized.slice(0, i);
+      const existing = prefixMap.get(prefix);
+      if (!existing) {
+        prefixMap.set(prefix, [word]);
+        continue;
+      }
+
+      if (existing.some(entry => normalize(entry) === normalized)) continue;
+      if (existing.length >= MAX_SUGGESTIONS_PER_PREFIX) continue;
+
+      existing.push(word);
     }
-    if (existing.includes(suggestion)) continue;
-    if (existing.length >= MAX_SUGGESTIONS_PER_PREFIX) continue;
-    existing.push(suggestion);
   }
+
+  return prefixMap;
 }
 
+const PREFIX_MAP = buildPrefixMap([
+  ...CURATED_WORDS,
+  ...STARTER_WORDS,
+]);
 
+export function getPrefixSuggestions(prefix: string, limit = 8): string[] {
+  const normalizedPrefix = normalize(prefix);
+  if (!normalizedPrefix) return [];
+
+  const exactMatch = PREFIX_MAP.get(normalizedPrefix);
+  if (exactMatch && exactMatch.length) {
+    return exactMatch.slice(0, limit);
+  }
+
+  for (let i = normalizedPrefix.length - 1; i > 0; i -= 1) {
+    const fallback = PREFIX_MAP.get(normalizedPrefix.slice(0, i));
+    if (fallback && fallback.length) {
+      return fallback.slice(0, limit);
+    }
+  }
+
+  return [];
 }
 
-/**
- * Returns the most frequent French words starting with the provided prefix.
- */
-
-}
-
-/**
- * A light-weight check to determine whether a prefix has any candidates.
- */
 export function hasPrefixSuggestions(prefix: string): boolean {
-
+  return getPrefixSuggestions(prefix, 1).length > 0;
+}


### PR DESCRIPTION
## Summary
- ensure suggestion chips insert a cleaned value when the input is empty or whitespace
- rework the spell suggestion hook to prioritise prefix/context matches and filter remote results by the active word
- rebuild the prefix suggester map from curated and starter vocab so contextual suggestions stay relevant

## Testing
- npm run lint *(fails: command prompts for interactive ESLint migration)*

------
https://chatgpt.com/codex/tasks/task_e_68daf7bfc3888325a634f63eeb1e6485