### PR TITLE
feat: enhance chat suggestions and display controls

### DIFF
--- a/src/components/chat/chat-window.tsx
+++ b/src/components/chat/chat-window.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import * as React from 'react';
-import { useState, useRef, useMemo, useEffect } from 'react';
+import { useState, useRef, useMemo, useEffect, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -17,6 +17,14 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Label } from '../ui/label';
 import { useSpellSuggestions } from '@/hooks/use-spell-suggestions';
+import { Switch } from '../ui/switch';
+import { Slider } from '../ui/slider';
+import { Badge } from '../ui/badge';
+import { SyllableText } from '../syllable-text';
+
+const MESSAGE_SCALE_MIN = 0.85;
+const MESSAGE_SCALE_MAX = 1.4;
+const MESSAGE_SCALE_STEP = 0.05;
 
 interface ChatWindowProps {
     conversationId: string | null;
@@ -32,9 +40,12 @@ export function ChatWindow({ conversationId, currentStudent, allStudents, isCrea
     const [newMessage, setNewMessage] = useState('');
     const [isLoading, setIsLoading] = useState(false);
     const [isSending, setIsSending] = useState(false);
-    
+    const [colorizeSyllables, setColorizeSyllables] = useState(false);
+    const [messageScale, setMessageScale] = useState(1);
+    const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(0);
+
     const { toast } = useToast();
-    const { wordSuggestions, isLoading: isLoadingSuggestions } = useSpellSuggestions(newMessage, "fr");
+    const { wordSuggestions, suggestionBuckets, isLoading: isLoadingSuggestions, refresh: refreshSuggestions } = useSpellSuggestions(newMessage, "fr");
 
     // State for correction dialog
     const [correctionTarget, setCorrectionTarget] = useState<Message | null>(null);
@@ -44,7 +55,65 @@ export function ChatWindow({ conversationId, currentStudent, allStudents, isCrea
     const scrollAreaRef = useRef<HTMLDivElement>(null);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const lastReadConversationId = useRef<string | null>(null);
-    
+
+    const messageFontSize = useMemo(() => Number((14 * messageScale).toFixed(2)), [messageScale]);
+    const messageMetaFontSize = useMemo(() => Number((11 * messageScale).toFixed(2)), [messageScale]);
+
+    const suggestionSignature = useMemo(() => wordSuggestions.join('|'), [wordSuggestions]);
+    const primarySuggestionSet = useMemo(() => new Set(wordSuggestions.map((value) => value.toLowerCase())), [wordSuggestions]);
+    const trimmedMessageLength = useMemo(() => newMessage.trim().length, [newMessage]);
+    const hasSuggestions = useMemo(
+        () => wordSuggestions.length > 0 || suggestionBuckets.some((bucket) => bucket.suggestions.length > 0),
+        [wordSuggestions, suggestionBuckets]
+    );
+    const hasTypedInput = useMemo(() => trimmedMessageLength > 0, [trimmedMessageLength]);
+    const canRefreshSuggestions = useMemo(
+        () => trimmedMessageLength >= 3,
+        [trimmedMessageLength]
+    );
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        try {
+            const storedColor = localStorage.getItem('chat:syllable-color');
+            if (storedColor !== null) {
+                setColorizeSyllables(storedColor === 'true');
+            }
+            const storedScale = localStorage.getItem('chat:message-scale');
+            if (storedScale) {
+                const parsed = parseFloat(storedScale);
+                if (!Number.isNaN(parsed)) {
+                    const clamped = Math.min(MESSAGE_SCALE_MAX, Math.max(MESSAGE_SCALE_MIN, parsed));
+                    setMessageScale(clamped);
+                }
+            }
+        } catch (error) {
+            console.warn('Impossible de charger les préférences de discussion', error);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        try {
+            localStorage.setItem('chat:syllable-color', String(colorizeSyllables));
+        } catch (error) {
+            console.warn('Impossible de sauvegarder la préférence de colorisation', error);
+        }
+    }, [colorizeSyllables]);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        try {
+            localStorage.setItem('chat:message-scale', messageScale.toString());
+        } catch (error) {
+            console.warn('Impossible de sauvegarder la taille des messages', error);
+        }
+    }, [messageScale]);
+
+    useEffect(() => {
+        setActiveSuggestionIndex(0);
+    }, [suggestionSignature]);
+
     useEffect(() => {
         if (scrollAreaRef.current) {
             scrollAreaRef.current.scrollTop = scrollAreaRef.current.scrollHeight;
@@ -87,12 +156,12 @@ export function ChatWindow({ conversationId, currentStudent, allStudents, isCrea
     }, [conversationId, allStudents, currentStudent.id]);
 
 
-    const handleSendMessage = async () => {
+    const handleSendMessage = useCallback(async () => {
         if (!newMessage.trim() || !conversationId) return;
-        
+
         setIsSending(true);
         const result = await sendMessage(conversationId, currentStudent.id, newMessage);
-        
+
         if (result.success) {
             setNewMessage('');
         } else {
@@ -102,9 +171,9 @@ export function ChatWindow({ conversationId, currentStudent, allStudents, isCrea
                 description: result.error || 'Une erreur est survenue.',
             });
         }
-        
+
         setIsSending(false);
-    };
+    }, [conversationId, currentStudent.id, newMessage, toast]);
     
     const handleStartConversation = async (otherStudent: Student) => {
         const newConversationId = await findOrCreateConversation(currentStudent, otherStudent);
@@ -131,7 +200,7 @@ export function ChatWindow({ conversationId, currentStudent, allStudents, isCrea
         setCorrectionTarget(null);
     };
     
-    const handleApplySuggestion = (suggestion: string) => {
+    const handleApplySuggestion = useCallback((suggestion: string) => {
         const normalizedSuggestion = suggestion.trim();
         if (!normalizedSuggestion) return;
 
@@ -152,7 +221,38 @@ export function ChatWindow({ conversationId, currentStudent, allStudents, isCrea
             return `${base}${normalizedSuggestion} `;
         });
         textareaRef.current?.focus();
-    }
+    }, []);
+
+    const handleApplySuggestionAtIndex = useCallback((index: number) => {
+        const suggestion = wordSuggestions[index];
+        if (!suggestion) return;
+        handleApplySuggestion(suggestion);
+    }, [handleApplySuggestion, wordSuggestions]);
+
+    const handleInputKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (wordSuggestions.length) {
+            if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                setActiveSuggestionIndex((prev) => (prev + 1) % wordSuggestions.length);
+                return;
+            }
+            if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                setActiveSuggestionIndex((prev) => (prev - 1 + wordSuggestions.length) % wordSuggestions.length);
+                return;
+            }
+            if (e.key === 'Tab') {
+                e.preventDefault();
+                handleApplySuggestionAtIndex(activeSuggestionIndex);
+                return;
+            }
+        }
+
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            handleSendMessage();
+        }
+    }, [wordSuggestions.length, handleApplySuggestionAtIndex, activeSuggestionIndex, handleSendMessage]);
     
 
     if (isCreatingNew) {
@@ -216,13 +316,29 @@ export function ChatWindow({ conversationId, currentStudent, allStudents, isCrea
                                             "max-w-xs md:max-w-md p-3 rounded-2xl cursor-pointer",
                                             isCurrentUser ? "bg-primary text-primary-foreground rounded-br-none" : "bg-secondary rounded-bl-none"
                                         )}>
-                                            <p className="text-sm whitespace-pre-wrap">{msg.text}</p>
+                                            <div
+                                                className="whitespace-pre-wrap break-words"
+                                                style={{ fontSize: `${messageFontSize}px`, lineHeight: 1.4 }}
+                                            >
+                                                {colorizeSyllables ? <SyllableText text={msg.text} /> : msg.text}
+                                            </div>
                                             {msg.correctedText && (
                                                 <div className="border-t border-white/30 mt-2 pt-2">
-                                                    <p className="text-sm font-medium whitespace-pre-wrap text-green-200">{msg.correctedText}</p>
+                                                    <div
+                                                        className={cn(
+                                                            'whitespace-pre-wrap font-medium',
+                                                            isCurrentUser ? 'text-emerald-100' : 'text-emerald-700'
+                                                        )}
+                                                        style={{ fontSize: `${messageFontSize}px`, lineHeight: 1.4 }}
+                                                    >
+                                                        {colorizeSyllables ? <SyllableText text={msg.correctedText} /> : msg.correctedText}
+                                                    </div>
                                                 </div>
                                             )}
-                                            <p className="text-xs text-right mt-1 opacity-70">
+                                            <p
+                                                className="text-right mt-1 opacity-70"
+                                                style={{ fontSize: `${messageMetaFontSize}px` }}
+                                            >
                                                 {format(msg.createdAt.toDate(), 'HH:mm')}
                                             </p>
                                         </div>
@@ -241,39 +357,119 @@ export function ChatWindow({ conversationId, currentStudent, allStudents, isCrea
                 </div>
             </ScrollArea>
              <div className="p-4 border-t space-y-2">
-                 {(wordSuggestions.length > 0 || isLoadingSuggestions) && (
-                    <div className="grid grid-cols-4 gap-2">
-                        {wordSuggestions.slice(0, 12).map((s, i) => (
-                            <Button key={s + i} size="sm" variant="outline" onMouseDown={() => handleApplySuggestion(s)}>{s}</Button>
-                        ))}
-                         {isLoadingSuggestions && <div className="col-span-4 flex justify-center"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>}
+                 {(hasSuggestions || isLoadingSuggestions || hasTypedInput) && (
+                    <div className="rounded-xl border bg-background/90 p-3 shadow-sm">
+                        <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                            <span className="flex items-center gap-2"><Sparkles className="h-4 w-4" /> Suggestions</span>
+                            <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-8 w-8"
+                                onClick={refreshSuggestions}
+                                disabled={isLoadingSuggestions || !canRefreshSuggestions}
+                                title="Rafraîchir les suggestions"
+                            >
+                                {isLoadingSuggestions ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                            </Button>
+                        </div>
+                        <div className="mt-2 flex gap-2 overflow-x-auto pb-1">
+                            {wordSuggestions.length ? (
+                                wordSuggestions.map((suggestion, index) => (
+                                    <Button
+                                        key={`${suggestion}-${index}`}
+                                        size="sm"
+                                        variant={activeSuggestionIndex === index ? 'secondary' : 'outline'}
+                                        onMouseDown={() => handleApplySuggestion(suggestion)}
+                                        onMouseEnter={() => setActiveSuggestionIndex(index)}
+                                        className="shrink-0"
+                                    >
+                                        {suggestion}
+                                        {activeSuggestionIndex === index && <span className="ml-2 text-[10px] text-muted-foreground">↹</span>}
+                                    </Button>
+                                ))
+                            ) : (
+                                <p className="text-xs text-muted-foreground">Commence à taper pour voir des idées !</p>
+                            )}
+                        </div>
+                        {suggestionBuckets.map((bucket) => {
+                            const filtered = bucket.suggestions.filter((value) => !primarySuggestionSet.has(value.toLowerCase()));
+                            if (!filtered.length) return null;
+
+                            return (
+                                <div key={bucket.id} className="mt-3 space-y-1">
+                                    <div className="flex items-center gap-2">
+                                        <Badge variant="secondary" className="text-[11px] font-medium uppercase tracking-wide">
+                                            {bucket.label}
+                                        </Badge>
+                                        {bucket.description && <span className="text-[11px] text-muted-foreground">{bucket.description}</span>}
+                                    </div>
+                                    <div className="flex flex-wrap gap-2">
+                                        {filtered.map((suggestion) => (
+                                            <Button
+                                                key={`${bucket.id}-${suggestion}`}
+                                                size="sm"
+                                                variant="outline"
+                                                onMouseDown={() => handleApplySuggestion(suggestion)}
+                                            >
+                                                {suggestion}
+                                            </Button>
+                                        ))}
+                                    </div>
+                                </div>
+                            );
+                        })}
                     </div>
                 )}
-                <div className="relative">
-                    <Textarea
-                        ref={textareaRef}
-                        id="chat-input"
-                        value={newMessage}
-                        onChange={(e) => setNewMessage(e.target.value)}
-                        onKeyDown={(e) => {
-                           if (e.key === 'Enter' && !e.shiftKey) {
-                               e.preventDefault();
-                               handleSendMessage();
-                           }
-                        }}
-                        placeholder="Écris ton message..."
-                        className="pr-12 min-h-[44px] h-11 resize-none"
-                        disabled={isSending}
-                        spellCheck
-                    />
-                    <Button
-                        size="icon"
-                        className="absolute right-1 bottom-1 h-9 w-9"
-                        onClick={handleSendMessage}
-                        disabled={isSending || !newMessage.trim()}
-                    >
-                       {isSending ? <Loader2 className="h-4 w-4 animate-spin"/> : <Send className="h-4 w-4" />}
-                    </Button>
+                <div className="flex flex-col gap-3 rounded-xl border bg-background/90 p-3 shadow-sm">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="flex items-center gap-3">
+                            <Switch
+                                id="toggle-syllables"
+                                checked={colorizeSyllables}
+                                onCheckedChange={(checked) => setColorizeSyllables(Boolean(checked))}
+                            />
+                            <Label htmlFor="toggle-syllables" className="text-sm">Coloriser les syllabes dans le fil</Label>
+                        </div>
+                        <div className="flex flex-col gap-2 sm:items-center sm:gap-3 sm:flex-row">
+                            <Label htmlFor="message-size" className="text-sm">Taille du texte</Label>
+                            <div className="flex items-center gap-3">
+                                <Slider
+                                    id="message-size"
+                                    min={MESSAGE_SCALE_MIN}
+                                    max={MESSAGE_SCALE_MAX}
+                                    step={MESSAGE_SCALE_STEP}
+                                    value={[messageScale]}
+                                    onValueChange={(value) => {
+                                        if (!value.length) return;
+                                        setMessageScale(Number(value[0]));
+                                    }}
+                                    className="w-40"
+                                />
+                                <span className="text-xs text-muted-foreground w-12 text-right">{Math.round(messageScale * 100)}%</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div className="relative">
+                        <Textarea
+                            ref={textareaRef}
+                            id="chat-input"
+                            value={newMessage}
+                            onChange={(e) => setNewMessage(e.target.value)}
+                            onKeyDown={handleInputKeyDown}
+                            placeholder="Écris ton message..."
+                            className="pr-12 min-h-[44px] h-20 resize-none"
+                            disabled={isSending}
+                            spellCheck
+                        />
+                        <Button
+                            size="icon"
+                            className="absolute right-1 bottom-1 h-9 w-9"
+                            onClick={handleSendMessage}
+                            disabled={isSending || !hasTypedInput}
+                        >
+                            {isSending ? <Loader2 className="h-4 w-4 animate-spin"/> : <Send className="h-4 w-4" />}
+                        </Button>
+                    </div>
                 </div>
             </div>
             


### PR DESCRIPTION
## Summary
- improve the spell suggestion hook with ranked remote results, reusable buckets, and a manual refresh helper
- refresh the chat composer UI with grouped suggestion chips, keyboard navigation, and persistent user preferences
- add chat options for syllable colour highlighting and a slider to adjust message text size

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dafcc99158832582735d08a03c30a9