### PR TITLE
Aligner la voiture lorsqu'elle avance

### DIFF
--- a/src/components/gear-racer-game.tsx
+++ b/src/components/gear-racer-game.tsx
@@ -362,16 +362,29 @@ export function GearRacerGame({
         if (Number.isFinite(slipHeading) && combinedSpeed > MIN_ALIGNMENT_SPEED) {
           const alignmentStrength =
             HEADING_ALIGNMENT_STRENGTH * clamp(combinedSpeed / MAX_SPEED, 0.2, 1);
-          car.heading += angleDifference(slipHeading, car.heading) * alignmentStrength * delta;
+          const forwardAlignmentBoost =
+            forwardSpeed > 0
+              ? clamp(
+                  forwardSpeed / (Math.abs(lateralSpeed) + 0.12),
+                  1,
+                  3,
+                )
+              : 1;
+          car.heading +=
+            angleDifference(slipHeading, car.heading) *
+            alignmentStrength *
+            forwardAlignmentBoost *
+            delta;
         }
 
         let visualHeading = car.heading;
         if (Number.isFinite(slipHeading) && combinedSpeed > MIN_ALIGNMENT_SPEED) {
-          const straightMotion =
-            Math.abs(forwardSpeed) / (Math.abs(forwardSpeed) + Math.abs(lateralSpeed) + 1e-6);
+          const driftInfluence =
+            Math.abs(lateralSpeed) /
+            (Math.abs(forwardSpeed) + Math.abs(lateralSpeed) + 1e-6);
           const steeringStability =
             1 - clamp(Math.abs(car.frontWheelAngle) / (FRONT_WHEEL_MAX_ANGLE * 0.55), 0, 1);
-          const visualBlend = straightMotion * steeringStability;
+          const visualBlend = driftInfluence * steeringStability;
           visualHeading = blendAngles(car.heading, slipHeading, visualBlend);
         }
 


### PR DESCRIPTION
## Summary
- accentue l'alignement du cap de la voiture sur sa trajectoire lorsqu'elle avance
- réduit l'influence visuelle du dérapage pour garder la voiture droite pendant l'accélération

## Testing
- npm run lint *(interrompu à cause d'une invite interactive de Next.js)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1b124e388325b9462e7513508545