### PR TITLE
Fix gear racer mouse steering

### DIFF
--- a/src/components/gear-racer-game.tsx
+++ b/src/components/gear-racer-game.tsx
@@ -242,7 +242,6 @@ export function GearRacerGame({
   }, [handlePointerUpdate]);
 
   const handlePointerMove = useCallback((event: ReactPointerEvent<HTMLCanvasElement>) => {
-    if (event.buttons === 0 && event.pointerType !== 'touch') return;
     handlePointerUpdate(event.clientX, event.clientY);
   }, [handlePointerUpdate]);
 


### PR DESCRIPTION
## Summary
- ensure mouse pointer movement updates the car target so steering works without holding the button

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68dd1d12a8188325a66cb53aaecf968f