### PR TITLE
Add Passé Composé exercise

### DIFF
--- a/src/ai/flows/passe-compose-flow.ts
+++ b/src/ai/flows/passe-compose-flow.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+import { ai } from '../genkit';
+
+const PasseComposeInputSchema = z.object({
+  auxiliaries: z.array(z.enum(['avoir', 'etre'])),
+  groups: z.array(z.enum(['1er', '2eme', '3eme'])),
+  theme: z.string().optional(),
+  count: z.number().default(10),
+});
+
+const PasseComposeOutputSchema = z.object({
+  questions: z.array(z.object({
+    sentence: z.string().describe("La phrase avec un trou pour le verbe (ex: 'Hier, nous _____ une pomme.')"),
+    answer: z.string().describe("Le verbe correctement conjugué au passé composé (ex: 'avons mangé')"),
+    options: z.array(z.string()).describe("3 options pour le QCM, incluant la bonne réponse et 2 distracteurs plausibles (erreurs d'accord, mauvais auxiliaire, mauvais participe passé)"),
+  }))
+});
+
+export const passeComposeFlow = ai.defineFlow({
+  name: 'passeComposeFlow',
+  inputSchema: PasseComposeInputSchema,
+  outputSchema: PasseComposeOutputSchema,
+}, async (input): Promise<z.infer<typeof PasseComposeOutputSchema>> => {
+
+  const prompt = `
+    Génère un exercice de conjugaison au passé composé en français.
+    Tu dois générer exactement ${input.count} phrases.
+
+    Contraintes pour les phrases :
+    - Auxiliaires autorisés : ${input.auxiliaries.join(', ')}
+    - Groupes de verbes autorisés : ${input.groups.join(', ')} (1er = -er, 2eme = -ir avec participe présent en -issant, 3eme = irréguliers).
+    ${input.theme ? `- Thème de l'exercice : ${input.theme}` : '- Thème libre, adapté pour des enfants.'}
+    - Fais attention à l'accord du participe passé avec l'auxiliaire 'être' (et avec 'avoir' si COD placé avant, mais évite de préférence les cas trop complexes pour des enfants).
+    - Varie les pronoms sujets (je, tu, il, elle, on, nous, vous, ils, elles) ou utilise des groupes nominaux (ex: 'Les enfants', 'Marie et Paul').
+
+    Pour chaque phrase, tu dois fournir :
+    1. 'sentence': La phrase avec un trou (indiqué par '_____') à la place du verbe conjugué au passé composé.
+    2. 'answer': La bonne réponse à insérer dans le trou (ex: 'sont allés', 'a fini').
+    3. 'options': Un tableau contenant exactement 3 choix pour un QCM.
+       - L'un des choix DOIT être la bonne réponse (identique à 'answer').
+       - Les 2 autres choix doivent être des erreurs courantes :
+         - Erreur d'auxiliaire (ex: 'ont allés' au lieu de 'sont allés')
+         - Erreur d'accord du participe passé (ex: 'sont allé' au lieu de 'sont allés' pour un sujet pluriel)
+         - Autre temps (ex: 'allons' au lieu de 'sommes allés')
+         - Participe passé mal formé (ex: 'a prendu' au lieu de 'a pris')
+
+    Assure-toi que les distracteurs ont l'air plausibles pour un enfant qui apprend le passé composé.
+  `;
+
+  const { output } = await ai.generate({
+    model: 'gemini-1.5-flash',
+    prompt: prompt,
+    output: {
+      schema: PasseComposeOutputSchema,
+    },
+  });
+
+  if (!output) {
+      throw new Error("Failed to generate passe compose questions");
+  }
+
+  return output;
+});

--- a/src/app/exercise/[skill]/page.tsx
+++ b/src/app/exercise/[skill]/page.tsx
@@ -196,6 +196,7 @@ export default function ExercisePage() {
       case 'ecoute-les-nombres':
       case 'syllabe-attaque':
       case 'currency':
+      case 'passe-compose':
       default:
         exerciseComponent = <ExerciseWorkspace skill={skill} />;
     }

--- a/src/components/exercise-workspace.tsx
+++ b/src/components/exercise-workspace.tsx
@@ -10,7 +10,7 @@ import { Button } from '../components/ui/button';
 import { cn } from '@/lib/utils';
 import { Check, Heart, Sparkles, Star, ThumbsUp, X, RefreshCw, Trash2, ArrowRight, Volume2, Keyboard, Gem } from 'lucide-react';
 import { AnalogClock } from '@/components/analog-clock';
-import { generateQuestions, type Question, type CalculationSettings as CalcSettings, type CurrencySettings as CurrSettings, type TimeSettings as TimeSettingsType, type CountSettings as CountSettingsType, type NumberLevelSettings } from '@/lib/questions';
+import { generateQuestions, type Question, type CalculationSettings as CalcSettings, type CurrencySettings as CurrSettings, type TimeSettings as TimeSettingsType, type CountSettings as CountSettingsType, type NumberLevelSettings, type PasseComposeSettings as PasseComposeSettingsType } from '@/lib/questions';
 import { currency as currencyData, formatCurrency } from '@/lib/currency';
 import { Progress } from '@/components/ui/progress';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -20,6 +20,7 @@ import { CurrencySettings } from '@/components/currency-settings';
 import { ChangeMakingSettings } from '@/components/change-making-settings';
 import { TimeSettings } from '@/components/time-settings';
 import { CountSettings } from '@/components/count-settings';
+import { PasseComposeSettings } from '@/components/passe-compose-settings';
 import { PriceTag } from '@/components/price-tag';
 import { InteractiveClock } from '@/components/interactive-clock';
 import { UserContext } from '@/context/user-context';
@@ -28,6 +29,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { Label } from './ui/label';
 import { VirtualKeyboard } from './virtual-keyboard';
 import { useToast } from '@/hooks/use-toast';
+import { Input } from './ui/input';
 
 
 const motivationalMessages = [
@@ -70,7 +72,9 @@ export function ExerciseWorkspace({ skill, isTableauMode = false }: ExerciseWork
   const [timeSettings, setTimeSettings] = useState<TimeSettingsType | null>(null);
   const [countSettings, setCountSettings] = useState<CountSettingsType | null>(null);
   const [numberLevelSettings, setNumberLevelSettings] = useState<NumberLevelSettings | null>(null);
+  const [passeComposeSettings, setPasseComposeSettings] = useState<PasseComposeSettingsType | null>(null);
   const [isReadyToStart, setIsReadyToStart] = useState(false);
+  const [isGenerating, setIsGenerating] = useState(false);
   
   // State for compose-sum
   const [composedAmount, setComposedAmount] = useState(0);
@@ -88,7 +92,7 @@ export function ExerciseWorkspace({ skill, isTableauMode = false }: ExerciseWork
 
   useEffect(() => {
     async function loadNonConfigurableQuestions() {
-        if (!['calculation', 'currency', 'change-making', 'time', 'denombrement', 'lire-les-nombres', 'mental-calculation', 'keyboard-count'].includes(skill.slug)) {
+        if (!['calculation', 'currency', 'change-making', 'time', 'denombrement', 'lire-les-nombres', 'mental-calculation', 'keyboard-count', 'passe-compose'].includes(skill.slug)) {
             const generatedQuestions = await generateQuestions(skill.slug, NUM_QUESTIONS);
             setQuestions(generatedQuestions);
             setIsReadyToStart(true);
@@ -143,6 +147,15 @@ export function ExerciseWorkspace({ skill, isTableauMode = false }: ExerciseWork
     setQuestions(generatedQuestions);
     setIsReadyToStart(true);
   }
+
+  const startPasseComposeExercise = async (settings: PasseComposeSettingsType) => {
+    setIsGenerating(true);
+    setPasseComposeSettings(settings);
+    const generatedQuestions = await generateQuestions(skill.slug, NUM_QUESTIONS, { passeCompose: settings });
+    setQuestions(generatedQuestions);
+    setIsGenerating(false);
+    setIsReadyToStart(true);
+  };
 
   const startCountExercise = async (settings: CountSettingsType) => {
     setCountSettings(settings);
@@ -406,9 +419,10 @@ export function ExerciseWorkspace({ skill, isTableauMode = false }: ExerciseWork
     setTimeSettings(null);
     setCountSettings(null);
     setNumberLevelSettings(null);
+    setPasseComposeSettings(null);
     resetInteractiveStates();
     
-    if (!['calculation', 'currency', 'change-making', 'time', 'denombrement', 'lire-les-nombres', 'mental-calculation', 'keyboard-count'].includes(skill.slug)) {
+    if (!['calculation', 'currency', 'change-making', 'time', 'denombrement', 'lire-les-nombres', 'mental-calculation', 'keyboard-count', 'passe-compose'].includes(skill.slug)) {
       const newQuestions = await generateQuestions(skill.slug, NUM_QUESTIONS);
       setQuestions(newQuestions);
       setIsReadyToStart(true);
@@ -437,12 +451,13 @@ export function ExerciseWorkspace({ skill, isTableauMode = false }: ExerciseWork
   };
 
   const hasConfigurableSettings = useMemo(() => 
-    ['calculation', 'currency', 'change-making', 'time', 'denombrement', 'lire-les-nombres'].includes(skill.slug), 
+    ['calculation', 'currency', 'change-making', 'time', 'denombrement', 'lire-les-nombres', 'passe-compose'].includes(skill.slug),
   [skill.slug]);
 
   if (!isReadyToStart && hasConfigurableSettings) {
       if (skill.slug === 'calculation') return <CalculationSettings onStart={startCalculationExercise} />;
       if (skill.slug === 'currency') return <CurrencySettings onStart={startCurrencyExercise} />;
+      if (skill.slug === 'passe-compose') return <PasseComposeSettings onStart={startPasseComposeExercise} isLoading={isGenerating} />;
       if (skill.slug === 'change-making') return <ChangeMakingSettings onStart={startNumberLevelExercise} />;
       if (skill.slug === 'time') {
           const initialDifficulty = student?.levels?.[skill.slug]
@@ -596,6 +611,55 @@ export function ExerciseWorkspace({ skill, isTableauMode = false }: ExerciseWork
          </div>
         <VirtualKeyboard onKeyPress={handleKeyboardCountKeystroke} numericOnly />
     </div>
+  );
+
+  const handleTextInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (feedback) return;
+    setUserKeyboardInput(e.target.value);
+  };
+
+  const handleTextInputSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (feedback) return;
+
+    if (userKeyboardInput.trim().toLowerCase() === exerciseData?.answer?.trim().toLowerCase()) {
+        processCorrectAnswer();
+    } else {
+        processIncorrectAnswer();
+    }
+  };
+
+  const renderTextInput = () => (
+    <form onSubmit={handleTextInputSubmit} className="flex flex-col items-center justify-center space-y-6 w-full max-w-md mx-auto">
+        <div className="relative w-full">
+            <Input
+                autoFocus
+                value={userKeyboardInput}
+                onChange={handleTextInputChange}
+                disabled={!!feedback}
+                className={cn(
+                    "text-center text-2xl h-16",
+                    feedback === 'correct' && 'border-green-500 bg-green-50 text-green-900',
+                    feedback === 'incorrect' && 'border-red-500 bg-red-50 text-red-900 animate-shake'
+                )}
+                placeholder="Tape ta réponse ici"
+            />
+            {feedback === 'correct' && <Check className="absolute right-4 top-1/2 -translate-y-1/2 h-6 w-6 text-green-500"/>}
+            {feedback === 'incorrect' && <X className="absolute right-4 top-1/2 -translate-y-1/2 h-6 w-6 text-red-500"/>}
+        </div>
+        {feedback === 'incorrect' && (
+            <div className="text-red-500 font-bold text-lg">
+                La bonne réponse était : {exerciseData.answer}
+            </div>
+        )}
+        <Button
+            type="submit"
+            disabled={!!feedback || userKeyboardInput.trim() === ''}
+            className="w-full h-12 text-lg"
+        >
+            Valider
+        </Button>
+    </form>
   );
 
   const renderQCM = () => (
@@ -881,6 +945,7 @@ const renderWrittenToAudioQCM = () => (
           {exerciseData.type === 'count' && renderCount()}
           {exerciseData.type === 'keyboard-count' && renderKeyboardCount()}
           {exerciseData.type === 'written-to-audio-qcm' && renderWrittenToAudioQCM()}
+          {exerciseData.type === 'text-input' && renderTextInput()}
         </CardContent>
         <CardFooter className="h-24 flex items-center justify-center">
           {feedback === 'correct' && (

--- a/src/components/passe-compose-settings.tsx
+++ b/src/components/passe-compose-settings.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useState } from 'react';
+import { Card, CardHeader, CardTitle, CardContent, CardFooter, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import type { PasseComposeSettings } from '@/lib/questions';
+import { Loader2 } from 'lucide-react';
+
+interface PasseComposeSettingsProps {
+  onStart: (settings: PasseComposeSettings) => void;
+  isLoading?: boolean;
+}
+
+export function PasseComposeSettings({ onStart, isLoading }: PasseComposeSettingsProps) {
+  const [auxiliaries, setAuxiliaries] = useState<('avoir' | 'etre')[]>(['avoir', 'etre']);
+  const [groups, setGroups] = useState<('1er' | '2eme' | '3eme')[]>(['1er']);
+  const [theme, setTheme] = useState('');
+  const [answerMode, setAnswerMode] = useState<'qcm' | 'text'>('qcm');
+
+  const handleSubmit = () => {
+    if (auxiliaries.length === 0 || groups.length === 0) return;
+    onStart({ auxiliaries, groups, theme: theme.trim() || undefined, answerMode });
+  };
+
+  const handleAuxiliaryChange = (value: 'avoir' | 'etre') => {
+    setAuxiliaries(prev =>
+      prev.includes(value) ? prev.filter(a => a !== value) : [...prev, value]
+    );
+  };
+
+  const handleGroupChange = (value: '1er' | '2eme' | '3eme') => {
+    setGroups(prev =>
+      prev.includes(value) ? prev.filter(g => g !== value) : [...prev, value]
+    );
+  };
+
+  const isFormValid = auxiliaries.length > 0 && groups.length > 0;
+
+  return (
+    <Card className="w-full max-w-2xl mx-auto shadow-2xl">
+      <CardHeader>
+        <CardTitle className="font-headline text-3xl text-center">Paramètres de l'exercice</CardTitle>
+        <CardDescription className="text-center">Choisis les options pour générer des phrases au passé composé.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-8 p-8">
+
+        <div className="space-y-4">
+          <Label className="text-lg font-bold">Auxiliaires</Label>
+          <div className="flex gap-4">
+            <div className="flex items-center space-x-2">
+              <Checkbox id="aux-avoir" checked={auxiliaries.includes('avoir')} onCheckedChange={() => handleAuxiliaryChange('avoir')} />
+              <Label htmlFor="aux-avoir" className="font-normal">Avoir</Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <Checkbox id="aux-etre" checked={auxiliaries.includes('etre')} onCheckedChange={() => handleAuxiliaryChange('etre')} />
+              <Label htmlFor="aux-etre" className="font-normal">Être</Label>
+            </div>
+          </div>
+          {auxiliaries.length === 0 && <p className="text-red-500 text-sm">Veuillez sélectionner au moins un auxiliaire.</p>}
+        </div>
+
+        <div className="space-y-4">
+          <Label className="text-lg font-bold">Groupes de verbes</Label>
+          <div className="flex gap-4 flex-wrap">
+            <div className="flex items-center space-x-2">
+              <Checkbox id="grp-1" checked={groups.includes('1er')} onCheckedChange={() => handleGroupChange('1er')} />
+              <Label htmlFor="grp-1" className="font-normal">1er groupe (-er)</Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <Checkbox id="grp-2" checked={groups.includes('2eme')} onCheckedChange={() => handleGroupChange('2eme')} />
+              <Label htmlFor="grp-2" className="font-normal">2ème groupe (-ir)</Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <Checkbox id="grp-3" checked={groups.includes('3eme')} onCheckedChange={() => handleGroupChange('3eme')} />
+              <Label htmlFor="grp-3" className="font-normal">3ème groupe (irréguliers)</Label>
+            </div>
+          </div>
+          {groups.length === 0 && <p className="text-red-500 text-sm">Veuillez sélectionner au moins un groupe de verbes.</p>}
+        </div>
+
+        <div className="space-y-4">
+          <Label htmlFor="theme" className="text-lg font-bold">Thème (Optionnel)</Label>
+          <Input
+            id="theme"
+            placeholder="Ex: Les pirates, le football, la forêt..."
+            value={theme}
+            onChange={(e) => setTheme(e.target.value)}
+          />
+          <p className="text-sm text-muted-foreground">L'intelligence artificielle créera des phrases sur ce thème.</p>
+        </div>
+
+        <div className="space-y-4">
+          <Label className="text-lg font-bold">Mode de réponse</Label>
+          <RadioGroup value={answerMode} onValueChange={(value) => setAnswerMode(value as 'qcm' | 'text')} className="flex gap-4">
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="qcm" id="mode-qcm" />
+              <Label htmlFor="mode-qcm" className="font-normal">Choix multiple (QCM)</Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="text" id="mode-text" />
+              <Label htmlFor="mode-text" className="font-normal">Écrire au clavier</Label>
+            </div>
+          </RadioGroup>
+        </div>
+
+      </CardContent>
+      <CardFooter>
+        <Button onClick={handleSubmit} size="lg" className="w-full text-xl py-7" disabled={!isFormValid || isLoading}>
+          {isLoading ? <><Loader2 className="mr-2 animate-spin" /> Génération des phrases...</> : "Commencer l'exercice !"}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/lib/passe-compose-questions.ts
+++ b/src/lib/passe-compose-questions.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import { passeComposeFlow } from '@/ai/flows/passe-compose-flow';
+import type { PasseComposeSettings, Question } from './questions';
+
+export async function generatePasseComposeQuestions(
+  settings: PasseComposeSettings,
+  count: number
+): Promise<Question[]> {
+  const result = await passeComposeFlow({
+    auxiliaries: settings.auxiliaries,
+    groups: settings.groups,
+    theme: settings.theme,
+    count,
+  });
+
+  if (!result || !result.questions) {
+    throw new Error('Failed to generate questions');
+  }
+
+  return result.questions.map((q: any, index: number) => ({
+    id: Date.now() + index,
+    level: 'B',
+    type: settings.answerMode === 'qcm' ? 'qcm' : 'text-input',
+    question: q.sentence,
+    options: settings.answerMode === 'qcm' ? q.options : undefined,
+    answer: q.answer,
+    passeComposeSettings: settings,
+  }));
+}

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -21,7 +21,7 @@ import { generateGnNiQuestions } from './gn-ni-questions';
 export interface Question {
   id: number;
   level: SkillLevel;
-  type: 'qcm' | 'set-time' | 'count' | 'audio-qcm' | 'written-to-audio-qcm' | 'audio-to-text-input' | 'keyboard-count' | 'image-qcm' | 'click-date' | 'count-days' | 'compose-sum' | 'select-multiple' | 'drag-and-drop-recognition' | 'qcm-image' | 'mystery-number';
+  type: 'qcm' | 'set-time' | 'count' | 'audio-qcm' | 'written-to-audio-qcm' | 'audio-to-text-input' | 'keyboard-count' | 'image-qcm' | 'click-date' | 'count-days' | 'compose-sum' | 'select-multiple' | 'drag-and-drop-recognition' | 'qcm-image' | 'mystery-number' | 'text-input';
   question: string;
   // For adaptive mental math
   competencyId?: string;
@@ -69,6 +69,15 @@ export interface Question {
   correctValue?: number;
   boxLabel?: string;
   currencySettings?: CurrencySettings;
+  // For passe-compose
+  passeComposeSettings?: PasseComposeSettings;
+}
+
+export interface PasseComposeSettings {
+  auxiliaries: ('avoir' | 'etre')[];
+  groups: ('1er' | '2eme' | '3eme')[];
+  theme?: string;
+  answerMode: 'qcm' | 'text';
 }
 
 export interface CalculationSettings {
@@ -112,6 +121,7 @@ export interface AllSettings {
   readingRace?: ReadingRaceSettings;
   calculation?: CalculationSettings;
   currency?: CurrencySettings;
+  passeCompose?: PasseComposeSettings;
 }
 
 export async function generateQuestions(
@@ -195,6 +205,14 @@ export async function generateQuestions(
   if (skill === 'mystery-number') {
     // This exercise manages its own state, so we just need a placeholder
     return Promise.resolve([{ id: 1, level: 'B', type: 'mystery-number', question: '' }]);
+  }
+
+  if (skill === 'passe-compose' && settings?.passeCompose) {
+    // We will call the AI flow for generation. Need to import it or implement it here.
+    // However, since generateQuestions runs in a server action context, we can just call the flow here.
+    // For now, we will add the condition. The implementation will be linked when the flow is created.
+    const { generatePasseComposeQuestions } = await import('./passe-compose-questions');
+    return generatePasseComposeQuestions(settings.passeCompose, count);
   }
 
   // Fallback

--- a/src/lib/skills.tsx
+++ b/src/lib/skills.tsx
@@ -317,6 +317,14 @@ export const skills: Skill[] = [
     isFixedLevel: 'A',
   },
   {
+    name: 'Le Passé Composé',
+    slug: 'passe-compose',
+    description: 'Conjugue le verbe au passé composé.',
+    icon: <PenLine />,
+    category: 'Conjugaison',
+    allowedLevels: ['B', 'C', 'D'],
+  },
+  {
     name: 'Dictée de mots',
     slug: 'spelling',
     description: 'Écoute un mot et écris-le correctement.',


### PR DESCRIPTION
This adds a new interactive conjugation exercise for the "passé composé". Users can configure the exercise by choosing the auxiliary (avoir/être), the verb groups, an optional theme, and the answer mode (QCM or text input). The questions are dynamically generated using a Genkit AI flow to provide contextual and pedagogically relevant sentences.

---
*PR created automatically by Jules for task [1749091071980329035](https://jules.google.com/task/1749091071980329035) started by @manuguilbert9*